### PR TITLE
Adjust grid view to four columns

### DIFF
--- a/app/Resources/public/css/base.css
+++ b/app/Resources/public/css/base.css
@@ -10346,7 +10346,7 @@ ul.dropdown-menu.inner > li > a {
         clear: none;
     }
 
-    .grid-courses .col-md-4:nth-child(3n+1) {
+    .grid-courses .col-md-3:nth-child(4n+1) {
         clear: left;
     }
 

--- a/main/template/default/user_portal/grid_courses_with_category.tpl
+++ b/main/template/default/user_portal/grid_courses_with_category.tpl
@@ -9,7 +9,7 @@
             <div class="panel-body">
                 <div class="row">
                     {% for item in category.courses %}
-                        <div class="col-xs-12 col-sm-6 col-md-4">
+                        <div class="col-xs-12 col-sm-6 col-md-3">
                             <div class="items">
                                 <div class="image">
                                     {% set title %}

--- a/main/template/default/user_portal/grid_courses_without_category.tpl
+++ b/main/template/default/user_portal/grid_courses_without_category.tpl
@@ -2,7 +2,7 @@
     <div class="grid-courses">
         <div class="row">
             {% for item in courses %}
-                <div class="col-xs-12 col-sm-6 col-md-4">
+                <div class="col-xs-12 col-sm-6 col-md-3">
                     <div class="items my-courses">
                         <div class="image">
                             {% set title %}

--- a/main/template/default/user_portal/grid_session.tpl
+++ b/main/template/default/user_portal/grid_session.tpl
@@ -1,7 +1,7 @@
 {% set group_courses = 'view_grid_courses_grouped_categories_in_sessions'| api_get_configuration_value %}
 
 {% macro course_block(course, show_category) %}
-    <div class="col-xs-12 col-sm-6 col-md-4">
+    <div class="col-xs-12 col-sm-6 col-md-3">
         <div class="items items-sessions">
             <div class="image">
                 {% set title %}


### PR DESCRIPTION
## Summary
- display 4 columns for courses and sessions when grid view is enabled
- update clearing CSS rule for new grid layout

## Testing
- `composer validate --no-check-all` *(fails: command not found)*
- `php -l main/template/default/user_portal/grid_session.tpl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6d329a8c832bad4310d59454f82d