### PR TITLE
Fix pending attempts Excel export

### DIFF
--- a/main/inc/lib/exercise.lib.php
+++ b/main/inc/lib/exercise.lib.php
@@ -2441,6 +2441,8 @@ HOTSPOT;
         $courseId = $values['course_id'] ?? 0;
         $exerciseId = $values['exercise_id'] ?? 0;
         $status = $values['status'] ?? 0;
+        $questionType = $values['questionType'] ?? ($values['questionTypeId'] ?? 0);
+        $showAttemptsInSessions = api_get_configuration_value('show_exercise_attempts_in_all_user_sessions');
         $whereCondition = '';
         if (isset($_GET['filter_by_user']) && !empty($_GET['filter_by_user'])) {
             $filter_user = (int) $_GET['filter_by_user'];
@@ -2486,7 +2488,10 @@ HOTSPOT;
             false,
             false,
             true,
-            $status
+            $status,
+            $showAttemptsInSessions,
+            $questionType,
+            true
         );
 
         if (!empty($result)) {


### PR DESCRIPTION
## Summary
- ensure pending export considers question type and session attempts

## Testing
- `php -l main/inc/lib/exercise.lib.php` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b54e720ec832bbf5d4eb379fae343