### PR TITLE
Allow category managers to view all category tickets

### DIFF
--- a/main/ticket/ticket_details.php
+++ b/main/ticket/ticket_details.php
@@ -134,10 +134,14 @@ $userIsAllowInProject = TicketManager::userIsAllowInProject($userInfo, $projectI
 $allowEdition = $ticket['ticket']['assigned_last_user'] == $user_id ||
     $ticket['ticket']['sys_insert_user_id'] == $user_id ||
     $isAdmin;
+$allowCategory = TicketManager::userIsAssignedToCategory(
+    $user_id,
+    $ticket['ticket']['category_id']
+);
 
 if (false === $userIsAllowInProject) {
-    // make sure it's either a user assigned to this ticket, or the reporter, or and admin
-    if (false === $allowEdition) {
+    // make sure it's either a user assigned to this ticket, the reporter, an admin or the category manager
+    if (false === $allowEdition && false === $allowCategory) {
         api_not_allowed(true);
     }
 }


### PR DESCRIPTION
## Summary
- add a helper to get ticket categories assigned to a user
- let category managers see all tickets from their categories in listings and counts
- permit category managers to open tickets details

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68701685c818832b9e904bdf8fc5236f