### PR TITLE
Fix session progress average computation

### DIFF
--- a/main/mySpace/myStudents.php
+++ b/main/mySpace/myStudents.php
@@ -1339,7 +1339,8 @@ if (empty($details)) {
             $totalScore = 0;
             $totalProgress = 0;
             $gradeBookTotal = [0, 0];
-            $totalCourses = count($courses);
+            // Count only courses where the user is subscribed
+            $totalCourses = 0;
             $scoreDisplay = ScoreDisplay::instance();
             $theoreticalTime = 0;
             $totalTheoreticalTime = 0;
@@ -1364,6 +1365,8 @@ if (empty($details)) {
                 }
 
                 if ($isSubscribed) {
+                    // Increment courses count only when the student is subscribed
+                    $totalCourses++;
                     $timeInSeconds = Tracking::get_time_spent_on_the_course(
                         $student_id,
                         $courseId,


### PR DESCRIPTION
## Summary
- adjust course count to include only subscribed courses
- compute totals without intermediate variables

## Testing
- `php -l main/mySpace/myStudents.php`


------
https://chatgpt.com/codex/tasks/task_e_687fa8170950832baabefe107ebfc35a