### PR TITLE
Plugin user profile

### DIFF
--- a/main/admin/index.php
+++ b/main/admin/index.php
@@ -10,6 +10,12 @@ $cidReset = true;
 
 // Including some necessary chamilo files.
 require_once __DIR__.'/../inc/global.inc.php';
+$profilePluginEnabled = api_get_configuration_value('plugin_user_profile_enabled');
+$pluginInstalled = AppPlugin::getInstance()->isInstalled('user_profile');
+if ($profilePluginEnabled && $pluginInstalled) {
+    require_once api_get_path(SYS_PLUGIN_PATH).'user_profile/config.php';
+    require_once api_get_path(SYS_PLUGIN_PATH).'user_profile/UserProfilePlugin.php';
+}
 
 // Setting the section (for the tabs).
 $this_section = SECTION_PLATFORM_ADMIN;
@@ -142,6 +148,13 @@ if (api_is_platform_admin()) {
         'url' => 'extra_fields.php?type=user',
         'label' => get_lang('ManageUserFields'),
     ];
+    if ($profilePluginEnabled && $pluginInstalled) {
+        $items[] = [
+            'class' => 'item-user-profile-plugin',
+            'url' => '../plugin/user_profile/admin.php',
+            'label' => get_plugin_lang('UserProfile', 'UserProfilePlugin'),
+        ];
+    }
     $items[] = [
         'class' => 'item-user-groups',
         'url' => 'usergroups.php',

--- a/main/admin/user_add.php
+++ b/main/admin/user_add.php
@@ -5,6 +5,14 @@
 $cidReset = true;
 // Including necessary libraries.
 require_once __DIR__.'/../inc/global.inc.php';
+$profilePluginEnabled = api_get_configuration_value('plugin_user_profile_enabled');
+$pluginInstalled = AppPlugin::getInstance()->isInstalled('user_profile');
+$profilePlugin = null;
+if ($profilePluginEnabled && $pluginInstalled) {
+    require_once api_get_path(SYS_PLUGIN_PATH).'user_profile/config.php';
+    require_once api_get_path(SYS_PLUGIN_PATH).'user_profile/UserProfilePlugin.php';
+    $profilePlugin = UserProfilePlugin::create();
+}
 
 // Section for the tabs
 $this_section = SECTION_PLATFORM_ADMIN;
@@ -320,6 +328,11 @@ $returnParams = $extraField->addElements(
     false,
     true
 );
+$profilePluginEnabled = api_get_configuration_value('plugin_user_profile_enabled');
+$pluginInstalled = AppPlugin::getInstance()->isInstalled('user_profile');
+if ($profilePluginEnabled && $pluginInstalled) {
+    $profilePlugin->addFieldsToForm($form);
+}
 
 $allowEmailTemplate = api_get_configuration_value('mail_template_system');
 if ($allowEmailTemplate) {
@@ -483,6 +496,9 @@ if ($form->validate()) {
             $extraFieldValues = new ExtraFieldValue('user');
             $user['item_id'] = $user_id;
             $extraFieldValues->saveFieldValues($user);
+            if ($profilePluginEnabled && $pluginInstalled) {
+                $profilePlugin->saveUserValues($user_id, $user);
+            }
             $message = get_lang('UserAdded').': '.
                 Display::url(
                     api_get_person_name($firstname, $lastname),

--- a/main/admin/user_edit.php
+++ b/main/admin/user_edit.php
@@ -6,6 +6,14 @@ use ChamiloSession as Session;
 
 $cidReset = true;
 require_once __DIR__.'/../inc/global.inc.php';
+$profilePluginEnabled = api_get_configuration_value('plugin_user_profile_enabled');
+$pluginInstalled = AppPlugin::getInstance()->isInstalled('user_profile');
+$profilePlugin = null;
+if ($profilePluginEnabled && $pluginInstalled) {
+    require_once api_get_path(SYS_PLUGIN_PATH).'user_profile/config.php';
+    require_once api_get_path(SYS_PLUGIN_PATH).'user_profile/UserProfilePlugin.php';
+    $profilePlugin = UserProfilePlugin::create();
+}
 
 $this_section = SECTION_PLATFORM_ADMIN;
 
@@ -384,6 +392,9 @@ $returnParams = $extraField->addElements(
     false,
     true
 );
+if ($profilePluginEnabled && $pluginInstalled) {
+    $profilePlugin->addFieldsToForm($form, $user_data['user_id']);
+}
 $jqueryReadyContent = $returnParams['jquery_ready_content'];
 
 $allowEmailTemplate = api_get_configuration_value('mail_template_system');
@@ -558,6 +569,9 @@ if ($form->validate()) {
 
     $extraFieldValue = new ExtraFieldValue('user');
     $extraFieldValue->saveFieldValues($user);
+    if ($profilePluginEnabled && $pluginInstalled) {
+        $profilePlugin->saveUserValues($user_id, $user);
+    }
     $userInfo = api_get_user_info($user_id);
     $message = get_lang('UserUpdated').': '.Display::url(
         $userInfo['complete_name_with_username'],

--- a/main/admin/user_list.php
+++ b/main/admin/user_list.php
@@ -10,6 +10,14 @@ use ChamiloSession as Session;
  */
 $cidReset = true;
 require_once __DIR__.'/../inc/global.inc.php';
+$profilePluginEnabled = api_get_configuration_value('plugin_user_profile_enabled');
+$pluginInstalled = AppPlugin::getInstance()->isInstalled('user_profile');
+$profilePlugin = null;
+if ($profilePluginEnabled && $pluginInstalled) {
+    require_once api_get_path(SYS_PLUGIN_PATH).'user_profile/config.php';
+    require_once api_get_path(SYS_PLUGIN_PATH).'user_profile/UserProfilePlugin.php';
+    $profilePlugin = UserProfilePlugin::create();
+}
 
 api_protect_session_admin_list_users();
 
@@ -599,6 +607,12 @@ function modify_filter($user_id, $url_params, $row)
         if (!$user_is_anonymous) {
             $result .= '<a href="user_information.php?user_id='.$user_id.'">'.
                         Display::return_icon('info2.png', get_lang('Info')).'</a>&nbsp;&nbsp;';
+            if ($profilePluginEnabled && $pluginInstalled) {
+                $result .= Display::url(
+                    Display::return_icon('profile.png', get_lang('UserProfile')),
+                    $profilePlugin->getViewUrl($user_id)
+                ).'&nbsp;';
+            }
         } else {
             $result .= Display::return_icon('info2_na.png', get_lang('Info')).'&nbsp;&nbsp;';
         }

--- a/main/inc/lib/extra_field.lib.php
+++ b/main/inc/lib/extra_field.lib.php
@@ -1110,6 +1110,9 @@ class ExtraField extends Model
                             $defaults['extra_'.$field_details['variable']] = $field_details['default_value'];
                         }
                         if (!isset($form->_defaultValues['extra_'.$field_details['variable']])) {
+                            if (!isset($defaults)) {
+                                $defaults = [];
+                            }
                             $form->setDefaults($defaults);
                         }
                         if ($freezeElement) {

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -956,6 +956,8 @@ $_configuration['gradebook_badge_sidebar'] = [
 //$_configuration['messages_hide_mail_content'] = false;
 // If you install plugin redirection you need to change to true
 //$_configuration['plugin_redirection_enabled'] = false;
+// Enable the user profile plugin
+//$_configuration['plugin_user_profile_enabled'] = false;
 // Customize on hover agenda view. Show agenda comment and/or description
 /*$_configuration['agenda_on_hover_info'] = [
     'options' => [

--- a/plugin/user_profile/README.md
+++ b/plugin/user_profile/README.md
@@ -1,0 +1,31 @@
+User Profile Plugin
+===================
+
+This plugin adds a simple user information card. Administrators can define
+extra text or date fields and organise them into categories. Date fields can
+optionally be flagged for tracking. Categories are
+fully editable from the administration page: you may reorder them with
+drag‑and‑drop or delete them entirely. Deleting a category also removes all of
+its fields. Each user can then view a page showing
+the platform fields together with the custom fields. Field positions can also be
+changed with drag‑and‑drop and unwanted fields can be removed. You can add,
+remove, or reorder categories as needed from the administration page.
+
+If your platform uses the multi‑URL feature, each portal keeps its own set of
+categories and fields. The plugin automatically filters data by the current
+URL so values are never shared between portals.
+
+Created fields appear in the user creation and edition forms where administrators
+can fill values. A shortcut to view a user's profile card is available from the
+user list in the administration area.
+
+After installing the plugin remember to assign it to the `pre_footer` region so
+users can access their profile card easily.
+
+To activate the plugin add the following line to your `configuration.php` file:
+
+```
+$_configuration['plugin_user_profile_enabled'] = true;
+```
+
+Translations are available in English and French. You can add more languages by creating files in the `lang/` directory.

--- a/plugin/user_profile/UserProfilePlugin.php
+++ b/plugin/user_profile/UserProfilePlugin.php
@@ -1,0 +1,219 @@
+<?php
+/* For license terms, see /license.txt */
+require_once __DIR__.'/src/HookUserProfile.php';
+
+class UserProfilePlugin extends Plugin implements HookPluginInterface
+{
+    public const TABLE_FIELD = 'plugin_user_profile_field';
+    public const TABLE_VALUE = 'plugin_user_profile_value';
+    public const TABLE_CATEGORY = 'plugin_user_profile_category';
+
+    public function get_name(): string
+    {
+        return 'user_profile';
+    }
+
+    public static function getCategoryLabel(array $category): string
+    {
+        $name = $category['name'];
+        $label = self::create()->get_lang($name);
+
+        // get_lang() returns the key in brackets when missing; fallback to raw
+        if (preg_match('/^\[[=]?' . preg_quote($name, '/') . '[=]?\]$/', $label)) {
+            return $name;
+        }
+
+        return $label;
+    }
+
+    protected function __construct()
+    {
+        parent::__construct('1.0', 'Yannick VERHENNE');
+    }
+
+    public static function create(): UserProfilePlugin
+    {
+        static $instance = null;
+
+        return $instance ?: $instance = new self();
+    }
+
+    public function install()
+    {
+        $tblField = Database::get_main_table(self::TABLE_FIELD);
+        $tblValue = Database::get_main_table(self::TABLE_VALUE);
+        $tblCat = Database::get_main_table(self::TABLE_CATEGORY);
+        $urlId = api_get_current_access_url_id();
+
+        $sql = "CREATE TABLE IF NOT EXISTS $tblCat (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            access_url_id INT NOT NULL,
+            name VARCHAR(255) NOT NULL,
+            cat_order INT NOT NULL DEFAULT 0,
+            INDEX (access_url_id)
+        )";
+        Database::query($sql);
+
+        $sql = "CREATE TABLE IF NOT EXISTS $tblField (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            access_url_id INT NOT NULL,
+            name VARCHAR(255) NOT NULL,
+            field_type VARCHAR(10) NOT NULL,
+            category_id INT NOT NULL,
+            field_order INT NOT NULL DEFAULT 0,
+            FOREIGN KEY (category_id) REFERENCES $tblCat(id) ON DELETE CASCADE,
+            INDEX (access_url_id)
+        )";
+        Database::query($sql);
+
+        $sql = "CREATE TABLE IF NOT EXISTS $tblValue (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            user_id INT NOT NULL,
+            field_id INT NOT NULL,
+            value TEXT,
+            UNIQUE KEY uniq_user_field(user_id, field_id)
+        )";
+        Database::query($sql);
+
+        $this->installHook();
+    }
+
+    public function uninstall()
+    {
+        $tables = [self::TABLE_FIELD, self::TABLE_VALUE, self::TABLE_CATEGORY];
+        foreach ($tables as $table) {
+            $tableName = Database::get_main_table($table);
+            $sql = "DROP TABLE IF EXISTS $tableName";
+            Database::query($sql);
+        }
+
+        $this->uninstallHook();
+    }
+
+    public function installHook()
+    {
+        $observer = HookUserProfile::create();
+        HookCreateUser::create()->attach($observer);
+        HookUpdateUser::create()->attach($observer);
+        HookAdminBlock::create()->attach($observer);
+
+        return 1;
+    }
+
+    public function uninstallHook()
+    {
+        $observer = HookUserProfile::create();
+        HookCreateUser::create()->detach($observer);
+        HookUpdateUser::create()->detach($observer);
+        HookAdminBlock::create()->detach($observer);
+
+        return 1;
+    }
+
+    public function getAdminUrl()
+    {
+        return api_get_path(WEB_PLUGIN_PATH).$this->get_name().'/admin.php';
+    }
+
+    public function getViewUrl(int $userId, bool $fromSearch = false): string
+    {
+        $url = api_get_path(WEB_PLUGIN_PATH).$this->get_name().'/view.php?id='.$userId;
+        if ($fromSearch) {
+            $url .= '&from_search=1';
+        }
+        return $url;
+    }
+
+    public function getCategories(): array
+    {
+        $table = Database::get_main_table(self::TABLE_CATEGORY);
+        $urlId = api_get_current_access_url_id();
+        $res = Database::query("SELECT * FROM $table WHERE access_url_id = $urlId ORDER BY cat_order, id");
+        return Database::store_result($res);
+    }
+
+    public function getCategoryOptions(): array
+    {
+        $options = [];
+        foreach ($this->getCategories() as $cat) {
+            $options[$cat['id']] = self::getCategoryLabel($cat);
+        }
+        return $options;
+    }
+
+    public function getFields(): array
+    {
+        $table = Database::get_main_table(self::TABLE_FIELD);
+        $urlId = api_get_current_access_url_id();
+        $res = Database::query("SELECT * FROM $table WHERE access_url_id = $urlId ORDER BY field_order, id");
+        return Database::store_result($res);
+    }
+
+    public function addFieldsToForm(FormValidator $form, ?int $userId = null)
+    {
+        $values = [];
+        if ($userId) {
+            $values = $this->getUserValues($userId);
+        }
+
+        $fields = $this->getFields();
+        $byCat = [];
+        foreach ($fields as $field) {
+            $byCat[$field['category_id']][] = $field;
+        }
+
+        foreach ($this->getCategories() as $cat) {
+            $form->addHtml('<h5 style="text-align: center;"><strong>'.Security::remove_XSS($cat['name']).'</strong></h5></br>');
+            if (empty($byCat[$cat['id']])) {
+                continue;
+            }
+            foreach ($byCat[$cat['id']] as $field) {
+                $name = 'profile_'.$field['id'];
+                if ($field['field_type'] === 'date') {
+                    $form->addDatePicker($name, $field['name']);
+                } else {
+                    $form->addText($name, $field['name'], false);
+                }
+                if (isset($values[$field['id']])) {
+                    $form->setDefaults([$name => $values[$field['id']]]);
+                }
+            }
+        }
+    }
+
+    public function saveUserValues(int $userId, array $formValues)
+    {
+        $table = Database::get_main_table(self::TABLE_VALUE);
+        foreach ($this->getFields() as $field) {
+            $key = 'profile_'.$field['id'];
+            if (!array_key_exists($key, $formValues)) {
+                continue;
+            }
+            $value = trim((string) $formValues[$key]);
+            Database::delete($table, [
+                'user_id = ? AND field_id = ?' => [$userId, $field['id']],
+            ]);
+            if ($value !== '') {
+                Database::insert($table, [
+                    'user_id' => $userId,
+                    'field_id' => $field['id'],
+                    'value' => $value,
+                ]);
+            }
+        }
+    }
+
+    public function getUserValues(int $userId): array
+    {
+        $table = Database::get_main_table(self::TABLE_VALUE);
+        $rows = Database::select('*', $table, [
+            'where' => ['user_id = ?' => $userId],
+        ]);
+        $values = [];
+        foreach ($rows as $row) {
+            $values[$row['field_id']] = $row['value'];
+        }
+
+        return $values;
+    }
+}

--- a/plugin/user_profile/admin.php
+++ b/plugin/user_profile/admin.php
@@ -1,0 +1,256 @@
+<?php
+require_once __DIR__.'/config.php';
+require_once __DIR__.'/UserProfilePlugin.php';
+$enabled = api_get_configuration_value('plugin_user_profile_enabled');
+if (!$enabled) {
+    api_not_allowed(true);
+}
+$check = Security::check_token('request');
+$token = Security::get_token();
+
+api_protect_admin_script();
+$plugin = UserProfilePlugin::create();
+$urlId = api_get_current_access_url_id();
+$htmlHeadXtra[] = api_get_jquery_ui_js();
+$htmlHeadXtra[] = '<style>
+    .ui-sortable-placeholder {background:#fffae6;height:40px;}
+    .handle {cursor:move;text-align:center;width:30px;}
+    .user-profile-section {
+        border: 1px solid #eee;
+        border-radius: 4px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+        padding: 15px;
+        margin-bottom: 20px;
+    }
+    .search-form {max-width:500px;margin:0 auto;}
+    .search-form .search-input{width:100%;margin:10px;}
+</style>';
+
+$table = Database::get_main_table(UserProfilePlugin::TABLE_FIELD);
+$catTable = Database::get_main_table(UserProfilePlugin::TABLE_CATEGORY);
+
+if (isset($_GET['action']) && $_GET['action'] === 'delete' && isset($_GET['id'])) {
+    Database::delete($table, ['id = ? AND access_url_id = ?' => [(int) $_GET['id'], $urlId]]);
+    header('Location: '.api_get_self());
+    exit;
+}
+
+if (isset($_GET['action']) && $_GET['action'] === 'delete_cat' && isset($_GET['id'])) {
+    if ($check) {
+        if ($check) {
+        $categoryId = (int) $_GET['id'];
+        $valueTable = Database::get_main_table(UserProfilePlugin::TABLE_VALUE);
+
+        // Fetch all fields linked to the category so their values can be removed
+        $fields = Database::select('id', $table, [
+            'where' => ['category_id = ? AND access_url_id = ?' => [$categoryId, $urlId]],
+        ]);
+
+        foreach ($fields as $field) {
+            Database::delete($valueTable, ['field_id = ?' => $field['id']]);
+        }
+
+        Database::delete($table, ['category_id = ? AND access_url_id = ?' => [$categoryId, $urlId]]);
+        Database::delete($catTable, ['id = ? AND access_url_id = ?' => [$categoryId, $urlId]]);
+    }
+    Security::clear_token();
+    }
+    Security::clear_token();
+    header('Location: '.api_get_self());
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $check) {
+    if (isset($_POST['action']) && $_POST['action'] === 'reorder') {
+        $ids = array_map('intval', explode(',', $_POST['order']));
+        foreach ($ids as $pos => $id) {
+            Database::update(
+                $table,
+                ['field_order' => $pos],
+                ['id = ? AND access_url_id = ?' => [$id, $urlId]]
+            );
+        }
+        Security::clear_token();
+        exit;
+    }
+if (isset($_POST['action']) && $_POST['action'] === 'reorder_cat') {
+        $ids = array_map('intval', explode(',', $_POST['order']));
+        foreach ($ids as $pos => $id) {
+            Database::update(
+                $catTable,
+                ['cat_order' => $pos],
+                ['id = ? AND access_url_id = ?' => [$id, $urlId]]
+            );
+        }
+        Security::clear_token();
+        exit;
+    }
+
+    $name = trim($_POST['name'] ?? '');
+    $type = $_POST['field_type'] ?? 'text';
+    $categoryId = (int) ($_POST['category'] ?? 0);
+    if ($name !== '' && in_array($type, ['text', 'date']) && $categoryId) {
+        $res = Database::query("SELECT MAX(field_order) AS max_order FROM $table WHERE access_url_id = $urlId");
+        $row = Database::fetch_array($res);
+        $order = (int) $row['max_order'] + 1;
+        Database::insert($table, [
+            'access_url_id' => $urlId,
+            'name' => $name,
+            'field_type' => $type,
+            'category_id' => $categoryId,
+            'field_order' => $order,
+        ]);
+        Security::clear_token();
+        header('Location: '.api_get_self());
+        exit;
+    }
+
+    if (isset($_POST['new_category'])) {
+        $name = trim($_POST['new_category']);
+        if ($name !== '') {
+            $res = Database::query("SELECT MAX(cat_order) AS max_order FROM $catTable WHERE access_url_id = $urlId");
+            $row = Database::fetch_array($res);
+            $order = (int) $row['max_order'] + 1;
+            Database::insert($catTable, [
+                'access_url_id' => $urlId,
+                'name' => $name,
+                'cat_order' => $order,
+            ]);
+        }
+        Security::clear_token();
+        header('Location: '.api_get_self());
+        exit;
+    }
+}
+
+
+
+$fields = Database::query("SELECT f.*, c.name AS category_name FROM $table f LEFT JOIN $catTable c ON (f.category_id = c.id) WHERE f.access_url_id = $urlId AND c.access_url_id = $urlId ORDER BY f.field_order, f.id");
+
+$search = trim($_GET['search'] ?? '');
+$results = [];
+if (strlen($search) >= 3) {
+    $tblUser = Database::get_main_table(TABLE_MAIN_USER);
+    $tblUrl = Database::get_main_table(TABLE_MAIN_ACCESS_URL_REL_USER);
+    $escaped = Database::escape_string($search);
+    $condition = "(u.firstname LIKE '%$escaped%' OR u.lastname LIKE '%$escaped%')";
+    if (api_is_multiple_url_enabled()) {
+        $sql = "SELECT u.id, u.firstname, u.lastname FROM $tblUser u INNER JOIN $tblUrl url ON (u.id = url.user_id) WHERE url.access_url_id = $urlId AND $condition ORDER BY u.lastname, u.firstname";
+    } else {
+        $sql = "SELECT id, firstname, lastname FROM $tblUser u WHERE $condition ORDER BY u.lastname, u.firstname";
+    }
+    $res = Database::query($sql);
+    $results = Database::store_result($res);
+}
+
+Display::display_header(get_lang('UserProfile'));
+
+echo '<div class="user-profile-section">';
+echo Display::page_subheader(get_lang('SearchUser', 'user_profile'));
+echo '<div class="text-center mb-3">';
+echo '<form method="get" class="search-form">';
+echo '<input type="text" name="search" value="'.Security::remove_XSS($search).'" class="form-control mb-2 search-input" placeholder="'.get_lang('SearchUser', 'user_profile').'">';
+echo '<button type="submit" class="btn btn-primary">'.get_lang('Search').'</button>';
+echo '</form>';
+echo '</div>';
+
+if (!empty($results)) {
+    echo Display::page_subheader(get_lang('SearchResults', 'user_profile'));
+    echo '<table class="table table-hover table-striped">';
+    echo '<thead><tr><th>'.get_lang('FirstName').'</th><th>'.get_lang('LastName').'</th></tr></thead><tbody>';
+    foreach ($results as $user) {
+        $url = $plugin->getViewUrl((int) $user['id'], true);
+        $first = Display::url(Security::remove_XSS($user['firstname']), $url);
+        $last = Display::url(Security::remove_XSS($user['lastname']), $url);
+        echo "<tr><td>$first</td><td>$last</td></tr>";
+    }
+    echo '</tbody></table>';
+}
+echo '</div>';
+
+echo '<div class="user-profile-section">';
+echo Display::page_subheader(get_lang('CurrentFields'));
+echo '<table id="fields-table" class="table table-hover table-striped data_table">';
+echo '<thead><tr><th width="30"></th><th>'.get_lang('Name').'</th><th>'.get_lang('Type').'</th><th>'.get_lang('Category').'</th><th>'.get_lang('Actions').'</th></tr></thead><tbody>';
+while ($row = Database::fetch_array($fields)) {
+    echo '<tr id="field_'.$row['id'].'">';
+    echo '<td class="handle"><span style="font-size:1.4em;">&#9776;</span></td>';
+    echo '<td>'.Security::remove_XSS($row['name']).'</td>';
+    echo '<td>'.Security::remove_XSS($row['field_type']).'</td>';
+    $catLabel = UserProfilePlugin::getCategoryLabel(['name' => $row['category_name']]);
+    echo '<td>'.Security::remove_XSS($catLabel).'</td>';
+    $deleteUrl = api_get_self().'?sec_token='.$token.'&action=delete&id='.$row['id'];
+    echo '<td>'.Display::url(Display::return_icon('delete.png', get_lang('Delete')), $deleteUrl, ['onclick' => "return confirm('".addslashes(get_lang('ConfirmYourChoice'))."');"]).'</td>';
+    echo '</tr>';
+}
+echo '</tbody></table>';
+
+echo "<script>
+    $(function() {
+        $('#fields-table tbody').sortable({
+            handle: '.handle',
+            placeholder: 'ui-sortable-placeholder',
+            update: function() {
+                var ids = $(this).sortable('toArray');
+                var order = ids.map(function(id){ return id.replace('field_', ''); }).join(',');
+                $.post('".api_get_self()."', {sec_token: '$token', action: 'reorder', order: order});
+            }
+        }).disableSelection();
+    });
+</script>";
+
+$form = new FormValidator('add_field', 'post', api_get_self());
+$form->addHidden('sec_token', $token);  // ✅ Correct
+$form->addHidden('action', 'add');
+$form->addText('name', get_lang('Name'), false);
+$form->addSelect('field_type', get_lang('Type'), ['text' => 'Text', 'date' => 'Date']);
+$categories = $plugin->getCategoryOptions();
+$form->addSelect('category', get_lang('Category'), $categories);
+$form->addButtonSave(get_lang('Add'));
+$form->setConstants(['sec_token' => $token]);
+
+echo Display::page_subheader(get_lang('AddField'));
+$form->display();
+echo '</div>';
+
+echo '<div class="user-profile-section">';
+// Category management
+$categoriesRows = $plugin->getCategories();
+echo Display::page_subheader(get_lang('CurrentCategories'));
+echo '<table id="cats-table" class="table table-hover table-striped">';
+echo '<thead><tr><th width="30"></th><th>'.get_lang('Name').'</th><th>'.get_lang('Actions').'</th></tr></thead><tbody>';
+foreach ($categoriesRows as $cat) {
+    echo '<tr id="cat_'.$cat['id'].'">';
+    echo '<td class="handle"><span style="font-size:1.4em;">&#9776;</span></td>';
+    $label = UserProfilePlugin::getCategoryLabel($cat);
+    echo '<td>'.Security::remove_XSS($label).'</td>';
+    $delUrl = api_get_self().'?sec_token='.$token.'&action=delete_cat&id='.$cat['id'];
+    echo '<td>'.Display::url(Display::return_icon('delete.png', get_lang('Delete')), $delUrl, ['onclick' => "return confirm('".addslashes(get_lang('ConfirmYourChoice'))."');"]).'</td>';
+    echo '</tr>';
+}
+echo '</tbody></table>';
+
+echo "<script>
+    $(function(){
+        $('#cats-table tbody').sortable({
+            handle: '.handle',
+            placeholder: 'ui-sortable-placeholder',
+            update: function(){
+                var ids = $(this).sortable('toArray');
+                var order = ids.map(function(id){return id.replace('cat_','');}).join(',');
+                $.post('".api_get_self()."', {sec_token: '$token', action:'reorder_cat', order:order});
+            }
+        }).disableSelection();
+    });
+</script>";
+
+$catForm = new FormValidator('add_cat', 'post', api_get_self());
+$catForm->addHidden('sec_token', $token);
+$catForm->addText('new_category', get_lang('Name'), false);
+$catForm->addButtonSave(get_lang('Add'));
+$catForm->setConstants(['sec_token' => $token]);
+echo Display::page_subheader(get_lang('AddCategory'));
+$catForm->display();
+echo '</div>';
+
+Display::display_footer();

--- a/plugin/user_profile/config.php
+++ b/plugin/user_profile/config.php
@@ -1,0 +1,3 @@
+<?php
+/* For license terms, see /license.txt */
+require_once __DIR__.'/../../main/inc/global.inc.php';

--- a/plugin/user_profile/index.php
+++ b/plugin/user_profile/index.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__.'/config.php';
+if (!api_get_configuration_value('plugin_user_profile_enabled')) {
+    api_not_allowed(true);
+}
+require_once __DIR__.'/UserProfilePlugin.php';
+
+if (!api_is_anonymous()) {
+    $link = api_get_path(WEB_PLUGIN_PATH).'user_profile/view.php?id='.api_get_user_id();
+    echo '<p><a href="'.$link.'">'.get_lang('UserProfile').'</a></p>';
+}

--- a/plugin/user_profile/install.php
+++ b/plugin/user_profile/install.php
@@ -1,0 +1,8 @@
+<?php
+require_once __DIR__.'/config.php';
+require_once __DIR__.'/UserProfilePlugin.php';
+
+if (!api_is_platform_admin()) {
+    exit('You must have admin permissions to install plugins');
+}
+UserProfilePlugin::create()->install();

--- a/plugin/user_profile/lang/english.php
+++ b/plugin/user_profile/lang/english.php
@@ -1,0 +1,22 @@
+<?php
+$strings['plugin_title'] = 'User profile';
+$strings['plugin_comment'] = 'Displays a user profile card with custom fields.';
+$strings['UserProfile'] = 'User profile';
+$strings['Fields'] = 'Fields';
+$strings['AddField'] = 'Add field';
+$strings['CurrentFields'] = 'Current fields';
+$strings['AddCategory'] = 'Add category';
+$strings['CurrentCategories'] = 'Current categories';
+$strings['Category'] = 'Category';
+$strings['Administrative'] = 'Administrative';
+$strings['HostCompany'] = 'Host company';
+$strings['Contract'] = 'Contract';
+$strings['Pedagogy'] = 'Pedagogy';
+$strings['administratif'] = 'Administrative';
+$strings['entreprise'] = 'Host company';
+$strings['contrat'] = 'Contract';
+$strings['pedagogie'] = 'Pedagogy';
+$strings['PlatformFields'] = 'Platform fields';
+$strings['SearchUser'] = 'Search user';
+$strings['SearchResults'] = 'Search results';
+$strings['IncludeTracking'] = 'Include in tracking';

--- a/plugin/user_profile/lang/french.php
+++ b/plugin/user_profile/lang/french.php
@@ -1,0 +1,22 @@
+<?php
+$strings['plugin_title'] = 'Fiche utilisateur';
+$strings['plugin_comment'] = 'Affiche une fiche utilisateur avec des champs personnalisés.';
+$strings['UserProfile'] = 'Fiche utilisateur';
+$strings['Fields'] = 'Champs';
+$strings['AddField'] = 'Ajouter un champ';
+$strings['CurrentFields'] = 'Champs actuels';
+$strings['AddCategory'] = 'Ajouter une catégorie';
+$strings['CurrentCategories'] = 'Catégories actuelles';
+$strings['Category'] = 'Catégorie';
+$strings['Administrative'] = 'Administratif';
+$strings['HostCompany'] = "Entreprise d'accueil";
+$strings['Contract'] = 'Contrat';
+$strings['Pedagogy'] = 'Pédagogie';
+$strings['administratif'] = 'Administratif';
+$strings['entreprise'] = "Entreprise d'accueil";
+$strings['contrat'] = 'Contrat';
+$strings['pedagogie'] = 'Pédagogie';
+$strings['PlatformFields'] = 'Champs de la plateforme';
+$strings['SearchUser'] = 'Rechercher un utilisateur';
+$strings['SearchResults'] = 'Résultats de la recherche';
+$strings['IncludeTracking'] = 'Inclure dans le suivi';

--- a/plugin/user_profile/pdf.php
+++ b/plugin/user_profile/pdf.php
@@ -1,0 +1,84 @@
+<?php
+use Chamilo\CoreBundle\Component\Utils\ChamiloApi;
+
+require_once __DIR__.'/config.php';
+if (!api_get_configuration_value('plugin_user_profile_enabled')) {
+    api_not_allowed(true);
+}
+require_once __DIR__.'/UserProfilePlugin.php';
+
+$userId = (int) ($_GET['id'] ?? api_get_user_id());
+$info = api_get_user_info($userId);
+if (empty($info)) {
+    api_not_allowed(true);
+}
+
+$plugin = UserProfilePlugin::create();
+$urlId = api_get_current_access_url_id();
+$tblField = Database::get_main_table(UserProfilePlugin::TABLE_FIELD);
+$tblValue = Database::get_main_table(UserProfilePlugin::TABLE_VALUE);
+$tblCat = Database::get_main_table(UserProfilePlugin::TABLE_CATEGORY);
+$sql = "SELECT f.id, f.name, f.field_type, f.category_id, v.value, c.name AS category_name
+        FROM $tblField f
+        LEFT JOIN $tblValue v ON (f.id = v.field_id AND v.user_id = $userId)
+        LEFT JOIN $tblCat c ON (f.category_id = c.id)
+        WHERE f.access_url_id = $urlId AND c.access_url_id = $urlId
+        ORDER BY f.field_order, f.id";
+$result = Database::query($sql);
+$fields = Database::store_result($result);
+$fieldsByCat = [];
+foreach ($fields as $field) {
+    $fieldsByCat[$field['category_id']][] = $field;
+}
+$categories = $plugin->getCategories();
+
+ob_start();
+?>
+<h2><?php echo get_lang('UserProfile'); ?></h2>
+<div class="card user-profile mb-3">
+    <div class="card-title"><strong><?php echo get_plugin_lang('PlatformFields', 'user_profile'); ?></strong></div>
+    <ul class="list-group list-group-flush">
+        <li class="list-group-item"><strong><?php echo get_lang('FirstName'); ?>:</strong> <?php echo Security::remove_XSS($info['firstname']); ?></li>
+        <li class="list-group-item"><strong><?php echo get_lang('LastName'); ?>:</strong> <?php echo Security::remove_XSS($info['lastname']); ?></li>
+        <li class="list-group-item"><strong><?php echo get_lang('Email'); ?>:</strong> <?php echo Security::remove_XSS($info['email']); ?></li>
+        <li class="list-group-item"><strong><?php echo get_lang('OfficialCode'); ?>:</strong> <?php echo Security::remove_XSS($info['official_code']); ?></li>
+        <li class="list-group-item"><strong><?php echo get_lang('Phone'); ?>:</strong> <?php echo Security::remove_XSS($info['phone']); ?></li>
+        <li class="list-group-item"><strong><?php echo get_lang('RegistrationDate'); ?>:</strong> <?php echo Security::remove_XSS($info['registration_date']); ?></li>
+        <li class="list-group-item"><strong><?php echo get_lang('LastLogins'); ?>:</strong> <?php echo Security::remove_XSS($info['last_login']); ?></li>
+    </ul>
+</div>
+<div class="row">
+<?php foreach ($categories as $cat): ?>
+    <div class="col-md-6">
+        <div class="card user-profile mb-3">
+            <div class="card-title"><strong><?php echo Security::remove_XSS(UserProfilePlugin::getCategoryLabel($cat)); ?></strong></div>
+            <?php if (!empty($fieldsByCat[$cat['id']])): ?>
+            <ul class="list-group list-group-flush">
+                <?php foreach ($fieldsByCat[$cat['id']] as $field): ?>
+                <?php
+                $val = $field['value'];
+                if ($field['field_type'] === 'date' && !empty($val)) {
+                    $val = api_format_date($val, DATE_FORMAT_LONG);
+                }
+                ?>
+                <li class="list-group-item"><strong><?php echo Security::remove_XSS($field['name']); ?>:</strong> <?php echo Security::remove_XSS($val); ?></li>
+                <?php endforeach; ?>
+            </ul>
+            <?php endif; ?>
+        </div>
+    </div>
+<?php endforeach; ?>
+</div>
+<?php
+$html = ob_get_clean();
+
+$logo = ChamiloApi::getPlatformLogoPath('', true);
+$header = '<div style="text-align:right;"><img src="'.$logo.'" height="50"></div>';
+$date = api_format_date(api_get_local_time(), DATE_TIME_FORMAT_LONG);
+$footer = '<table width="100%"><tr><td>'.$date.'</td><td style="text-align:right">{PAGENO}/{nb}</td></tr></table>';
+
+$pdf = new PDF();
+$pdf->set_custom_header($header);
+$pdf->set_custom_footer($footer);
+$pdf->content_to_pdf($html, '', 'user_profile_'.$info['username']);
+

--- a/plugin/user_profile/plugin.php
+++ b/plugin/user_profile/plugin.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__.'/config.php';
+require_once __DIR__.'/UserProfilePlugin.php';
+
+$plugin_info = UserProfilePlugin::create()->get_info();

--- a/plugin/user_profile/src/HookUserProfile.php
+++ b/plugin/user_profile/src/HookUserProfile.php
@@ -1,0 +1,57 @@
+<?php
+/* For licensing terms, see /license.txt */
+
+class HookUserProfile extends HookObserver implements HookCreateUserObserverInterface, HookUpdateUserObserverInterface, HookAdminBlockObserverInterface
+{
+    protected function __construct()
+    {
+        parent::__construct('plugin/user_profile/UserProfilePlugin.php', 'user_profile');
+    }
+
+    public static function create(): self
+    {
+        static $instance = null;
+        return $instance ?: $instance = new self();
+    }
+
+    public function hookCreateUser(HookCreateUserEventInterface $hook)
+    {
+        if (!api_get_configuration_value('plugin_user_profile_enabled')) {
+            return 0;
+        }
+        if ($hook->getEventData()['type'] === HOOK_EVENT_TYPE_POST) {
+            $userId = $hook->getEventData()['return'];
+            UserProfilePlugin::create()->saveUserValues($userId, $_POST);
+        }
+    }
+
+    public function hookUpdateUser(HookUpdateUserEventInterface $hook)
+    {
+        if (!api_get_configuration_value('plugin_user_profile_enabled')) {
+            return 0;
+        }
+        if ($hook->getEventData()['type'] === HOOK_EVENT_TYPE_POST) {
+            $user = $hook->getEventData()['user'];
+            if (is_object($user) && method_exists($user, 'getId')) {
+                UserProfilePlugin::create()->saveUserValues($user->getId(), $_POST);
+            }
+        }
+    }
+
+    public function hookAdminBlock(HookAdminBlockEventInterface $hook)
+    {
+        if (!api_get_configuration_value('plugin_user_profile_enabled')) {
+            return 0;
+        }
+        $data = $hook->getEventData();
+        if ($data['type'] === HOOK_EVENT_TYPE_POST && isset($data['blocks']['user'])) {
+            $data['blocks']['user']['items'][] = [
+                'url' => UserProfilePlugin::create()->getAdminUrl(),
+                'label' => get_plugin_lang('UserProfile', 'user_profile'),
+            ];
+            return $data;
+        }
+
+        return 0;
+    }
+}

--- a/plugin/user_profile/uninstall.php
+++ b/plugin/user_profile/uninstall.php
@@ -1,0 +1,8 @@
+<?php
+require_once __DIR__.'/config.php';
+require_once __DIR__.'/UserProfilePlugin.php';
+
+if (!api_is_platform_admin()) {
+    exit('You must have admin permissions to uninstall plugins');
+}
+UserProfilePlugin::create()->uninstall();

--- a/plugin/user_profile/view.php
+++ b/plugin/user_profile/view.php
@@ -1,0 +1,114 @@
+<?php
+require_once __DIR__.'/config.php';
+if (!api_get_configuration_value('plugin_user_profile_enabled')) {
+    api_not_allowed(true);
+}
+require_once __DIR__.'/UserProfilePlugin.php';
+
+global $htmlHeadXtra;
+$htmlHeadXtra[] = '<style>
+    .user-profile.card {
+        border: 1px solid #eee;
+        border-radius: 4px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+        margin-bottom: 20px;
+    }
+    .user-profile .card-title {
+        font-weight: bold;
+        text-align: center;
+        background: #f7f7f7;
+        margin: 0;
+        padding: 10px;
+    }
+    .list-group-item {
+        border: 0px solid #ddd;
+    }
+</style>';
+
+$userId = (int) ($_GET['id'] ?? api_get_user_id());
+$info = api_get_user_info($userId);
+if (empty($info)) {
+    api_not_allowed(true);
+}
+
+$tblField = Database::get_main_table(UserProfilePlugin::TABLE_FIELD);
+$tblValue = Database::get_main_table(UserProfilePlugin::TABLE_VALUE);
+$tblCat = Database::get_main_table(UserProfilePlugin::TABLE_CATEGORY);
+
+$urlId = api_get_current_access_url_id();
+$sql = "SELECT f.id, f.name, f.field_type, f.category_id, v.value, c.name AS category_name
+        FROM $tblField f
+        LEFT JOIN $tblValue v ON (f.id = v.field_id AND v.user_id = $userId)
+        LEFT JOIN $tblCat c ON (f.category_id = c.id)
+        WHERE f.access_url_id = $urlId AND c.access_url_id = $urlId
+        ORDER BY f.field_order, f.id";
+$result = Database::query($sql);
+$fields = Database::store_result($result);
+$fieldsByCat = [];
+
+Display::display_header(get_lang('UserProfile'));
+
+$pdfUrl = api_get_path(WEB_PLUGIN_PATH).'user_profile/pdf.php?id='.$userId;
+$pdfLink = Display::url(
+    Display::return_icon('export_pdf.png', get_lang('ExportToPdf')),
+    $pdfUrl
+);
+$backLink = '';
+if (!empty($_GET['from_search'])) {
+    $backLink = Display::url(
+        Display::return_icon('back.png', get_lang('Back')),
+        UserProfilePlugin::create()->getAdminUrl(),
+        ['class' => 'mr-2']
+    );
+}
+echo '<div class="d-flex justify-content-between align-items-center">';
+echo '<h2>'.get_lang('UserProfile').'</h2>';
+echo '<div>'.$backLink.$pdfLink.'</div>';
+echo '</div>';
+
+// Built-in fields
+$built = [
+    get_lang('FirstName') => $info['firstname'],
+    get_lang('LastName') => $info['lastname'],
+    get_lang('Email') => $info['email'],
+    get_lang('OfficialCode') => $info['official_code'],
+    get_lang('Phone') => $info['phone'],
+    get_lang('RegistrationDate') => $info['registration_date'],
+    get_lang('LastLogin') => $info['last_login'],
+];
+echo '<div class="card user-profile mb-3">';
+echo '<div class="card-title"><strong>'.get_plugin_lang('PlatformFields', 'user_profile').'</strong></div>';
+echo '<ul class="list-group list-group-flush">';
+foreach ($built as $name => $value) {
+    echo '<li class="list-group-item"><strong>'.$name.':</strong> '.Security::remove_XSS($value).'</li>';
+}
+echo '</ul></div>';
+
+foreach ($fields as $field) {
+    $fieldsByCat[$field['category_id']][] = $field;
+}
+
+$categories = UserProfilePlugin::create()->getCategories();
+echo '<div class="row">';
+foreach ($categories as $cat) {
+    $catId = $cat['id'];
+$label = UserProfilePlugin::getCategoryLabel($cat);
+    echo '<div class="col-md-6">';
+    echo '<div class="card user-profile mb-3">';
+    echo '<div class="card-title"><strong>'.$label.'</strong></div>';
+    if (!empty($fieldsByCat[$catId])) {
+        echo '<ul class="list-group list-group-flush">';
+        foreach ($fieldsByCat[$catId] as $field) {
+            $val = $field['value'];
+            if ($field['field_type'] === 'date' && !empty($val)) {
+                $val = api_format_date($val, DATE_FORMAT_LONG);
+            }
+            echo '<li class="list-group-item"><strong>'.$field['name'].':</strong> '.Security::remove_XSS($val).'</li>';
+        }
+        echo '</ul>';
+    }
+    echo '</div></div>';
+}
+echo '</div>';
+
+Display::display_footer();


### PR DESCRIPTION
## Summary
- provide optional search parameter when linking to a user's profile and show a back icon when returning from results
- center the admin search bar, move its button below, and allow drag-and-drop sorting for fields and categories
- drop the unused `include_tracking` column from the field definition table

## Testing
- `php -l plugin/user_profile/admin.php`
- `php -l plugin/user_profile/UserProfilePlugin.php`


------
https://chatgpt.com/codex/tasks/task_e_6872ab21d210832bb0de3c28095e7bea