### PR TITLE
Plugin user profile V2

### DIFF
--- a/main/inc/lib/MyStudents.php
+++ b/main/inc/lib/MyStudents.php
@@ -60,6 +60,95 @@ class MyStudents
         return $table->toHtml();
     }
 
+    public static function getBlockForUserProfile(int $studentId): string
+    {
+        $enabled = api_get_configuration_value('plugin_user_profile_enabled');
+        $installed = AppPlugin::getInstance()->isInstalled('user_profile');
+        if (!$enabled || !$installed) {
+            return '';
+        }
+
+        require_once api_get_path(SYS_PLUGIN_PATH).'user_profile/config.php';
+        require_once api_get_path(SYS_PLUGIN_PATH).'user_profile/UserProfilePlugin.php';
+        $plugin = UserProfilePlugin::create();
+
+        $categories = $plugin->getCategories();
+        $fields = $plugin->getFields();
+        $values = $plugin->getUserValues($studentId);
+
+        $byCat = [];
+        foreach ($fields as $field) {
+            $byCat[$field['category_id']][] = $field;
+        }
+
+        $content = '';
+        $token = Security::get_token();
+        foreach ($categories as $cat) {
+            if (empty($byCat[$cat['id']])) {
+                continue;
+            }
+
+            $label = Security::remove_XSS(UserProfilePlugin::getCategoryLabel($cat));
+            $content .= '<div class="col-md-6">';
+            $content .= '<div class="card user-profile mb-3">';
+            $content .= '<div class="card-title"><strong>'.$label.'</strong></div>';
+            $content .= '<ul class="list-group list-group-flush">';
+            foreach ($byCat[$cat['id']] as $field) {
+                $valueData = $values[$field['id']] ?? ['value' => '', 'checked' => 0];
+                $rawValue = $valueData['value'];
+                $checked = !empty($valueData['checked']);
+                $valueHtml = '';
+                if ($field['field_type'] === 'date' && !empty($rawValue)) {
+                    $formatted = api_format_date($rawValue, DATE_FORMAT_SHORT);
+                    $safeFormatted = Security::remove_XSS($formatted);
+                    $isPast = strtotime($rawValue) < time();
+                    $class = 'text-success';
+                    $icon = '';
+                    if ($isPast && !$checked) {
+                        $class = 'text-danger';
+                        $icon = ' <em class="fa fa-exclamation-triangle"></em>';
+                    }
+                    $valueHtml = '<span class="profile-value profile-value-date '.$class.'" '
+                        .'data-formatted="'.$safeFormatted.'" data-overdue="'.($isPast ? 1 : 0).'">'
+                        .$safeFormatted.$icon.'</span>';
+                } else {
+                    $valueHtml = '<span class="profile-value">'
+                        .Security::remove_XSS($rawValue).'</span>';
+                }
+                $checkedAttr = $checked ? ' checked' : '';
+                $content .= '<li class="list-group-item"><input type="checkbox" class="profile-check" '
+                    .'data-user="'.$studentId.'" data-field="'.$field['id'].'"'.$checkedAttr.'> <strong>'
+                    .Security::remove_XSS($field['name']).'</strong>';
+                if ($rawValue !== '') {
+                    $content .= ': '.$valueHtml;
+                }
+                $content .= ' <span class="profile-status"></span></li>';
+            }
+            $content .= '</ul>';
+            $content .= '</div></div>';
+        }
+
+        if ('' === $content) {
+            return '';
+        }
+
+        $content = '<div class="row">'.$content.'</div>';
+        $url = api_get_path(WEB_PLUGIN_PATH).'user_profile/ajax.php';
+        $content .= "<script>\nvar profileToken = '$token';\n$(function(){\n    $('.profile-check').on('change', function(){\n        var el = $(this);\n        var li = el.closest('li');\n        $.post('$url', {\n            sec_token: profileToken,\n            action: 'toggle',\n            user_id: el.data('user'),\n            field_id: el.data('field'),\n            checked: el.is(':checked') ? 1 : 0\n        }, function(resp){\n            if(resp.token){ profileToken = resp.token; }\n            var span = li.find('.profile-value-date');\n            if(span.length){\n                var formatted = span.data('formatted');\n                var overdue = parseInt(span.data('overdue'),10) === 1;\n                if(overdue && !el.is(':checked')){\n                    span.attr('class','profile-value profile-value-date text-danger').html(formatted+' <em class=\\'fa fa-exclamation-triangle\\'></em>');\n                } else {\n                    span.attr('class','profile-value profile-value-date text-success').text(formatted);\n                }\n            }\n            li.find('.profile-status').text('ok').show().fadeOut(2000, function(){\n                $(this).text('');\n                $(this).show();\n            });\n        }, 'json');\n    });\n});\n</script>";
+
+        $title = get_lang('UserProfile', 'user_profile');
+
+        return Display::panelCollapse(
+            $title,
+            $content,
+            'panel-user-profile',
+            [],
+            'accordion-user-profile',
+            'collapse-user-profile',
+            false
+        );
+    }
+
     public static function getBlockForSkills(int $studentId, int $courseId, int $sessionId): string
     {
         $allowAll = api_get_configuration_value('allow_teacher_access_student_skills');

--- a/main/mySpace/myStudents.php
+++ b/main/mySpace/myStudents.php
@@ -1366,6 +1366,11 @@ if (api_get_configuration_value('improve_tracking_in_mystudent_php')) {
     echo Display::panel($sessionProgressHtml, '', '', 'default', $sessionProgressHeading);
 }
 
+$profileBlock = MyStudents::getBlockForUserProfile($student_id);
+if (!empty($profileBlock)) {
+    echo $profileBlock;
+    echo '<br /><br />';
+}
 echo MyStudents::getBlockForSkills(
     $student_id,
     $courseInfo ? $courseInfo['real_id'] : 0,

--- a/plugin/user_profile/UserProfilePlugin.php
+++ b/plugin/user_profile/UserProfilePlugin.php
@@ -192,7 +192,9 @@ class UserProfilePlugin extends Plugin implements HookPluginInterface
                     $form->addText($name, $field['name'], false);
                 }
                 if (isset($values[$field['id']])) {
-                    $form->setDefaults([$name => $values[$field['id']]]);
+                    $form->setDefaults([
+                        $name => $values[$field['id']]['value'],
+                    ]);
                 }
             }
         }
@@ -216,7 +218,7 @@ class UserProfilePlugin extends Plugin implements HookPluginInterface
                     'user_id' => $userId,
                     'field_id' => $field['id'],
                     'value' => $value,
-                    'include_tracking' => 0,
+                    'checked' => 0,
                 ]);
             }
         }
@@ -230,7 +232,10 @@ class UserProfilePlugin extends Plugin implements HookPluginInterface
         ]);
         $values = [];
         foreach ($rows as $row) {
-            $values[$row['field_id']] = $row['value'];
+            $values[$row['field_id']] = [
+                'value' => $row['value'],
+                'checked' => (int) $row['checked'],
+            ];
         }
 
         return $values;

--- a/plugin/user_profile/ajax.php
+++ b/plugin/user_profile/ajax.php
@@ -1,0 +1,80 @@
+<?php
+require_once __DIR__.'/config.php';
+if (!api_get_configuration_value('plugin_user_profile_enabled')) {
+    api_not_allowed(true);
+}
+require_once __DIR__.'/UserProfilePlugin.php';
+require_once api_get_path(LIBRARY_PATH).'message.lib.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $check = Security::check_token('post');
+    $status = 'error';
+    if ($check && isset($_POST['action'])) {
+        if ($_POST['action'] === 'toggle') {
+            $userId = (int) ($_POST['user_id'] ?? 0);
+            $fieldId = (int) ($_POST['field_id'] ?? 0);
+            $checked = (int) ($_POST['checked'] ?? 0);
+            $tblValue = Database::get_main_table(UserProfilePlugin::TABLE_VALUE);
+            $where = ['user_id = ? AND field_id = ?' => [$userId, $fieldId]];
+            $exists = Database::select('id', $tblValue, ['where' => $where], 'first');
+            if ($exists) {
+                Database::update($tblValue, ['checked' => $checked], $where);
+            } else {
+                Database::insert($tblValue, [
+                    'user_id' => $userId,
+                    'field_id' => $fieldId,
+                    'value' => '',
+                    'checked' => $checked,
+                ]);
+            }
+        } elseif ($_POST['action'] === 'warn') {
+            $userId = (int) ($_POST['user_id'] ?? 0);
+            $teacherId = (int) ($_POST['teacher_id'] ?? 0);
+            if ($userId && $teacherId) {
+                $tblUser = Database::get_main_table(TABLE_MAIN_USER);
+                $userInfo = Database::fetch_array(
+                    Database::query("SELECT firstname, lastname FROM $tblUser WHERE id = $userId"),
+                    'ASSOC'
+                );
+                $userName = $userInfo ? $userInfo['firstname'].' '.$userInfo['lastname'] : '';
+
+                $tblField = Database::get_main_table(UserProfilePlugin::TABLE_FIELD);
+                $tblValue = Database::get_main_table(UserProfilePlugin::TABLE_VALUE);
+                $tblCat = Database::get_main_table(UserProfilePlugin::TABLE_CATEGORY);
+                $urlId = api_get_current_access_url_id();
+                $sql = "SELECT f.name, f.field_type, v.value
+                        FROM $tblField f
+                        LEFT JOIN $tblValue v ON (f.id = v.field_id AND v.user_id = $userId)
+                        LEFT JOIN $tblCat c ON (f.category_id = c.id)
+                        WHERE f.access_url_id = $urlId AND c.access_url_id = $urlId
+                          AND f.include_tracking = 1 AND COALESCE(v.checked,0) = 0";
+                $res = Database::query($sql);
+                $lines = [];
+                while ($row = Database::fetch_array($res, 'ASSOC')) {
+                    $value = $row['value'];
+                    if ($row['field_type'] === 'date' && !empty($value)) {
+                        $value = api_format_date($value, DATE_FORMAT_LONG);
+                    }
+                    $lines[] = '- '.$row['name'].' : '.$value;
+                }
+                $intro = 'Bonjour, les éléments suivants méritent votre attention :';
+                $outro = 'Cordialement';
+
+                $userUrl = api_get_path(WEB_CODE_PATH).'mySpace/myStudents.php?student='.$userId;
+                $userLine = '<a href="'.$userUrl.'">'.$userName.'</a>';
+
+                $body = implode('<br>', $lines);
+                $content = $intro.'<br>'.$userLine.'<br>'.$body.'<br>'.$outro;
+
+                $subject = 'Avertissement pour '.$userName;
+                MessageManager::send_message_simple($teacherId, $subject, $content);
+            }
+            $status = 'ok';
+        }
+    }
+    Security::clear_token();
+    header('Content-Type: application/json');
+    echo json_encode(['token' => Security::get_token(), 'status' => $status]);
+    exit;
+}
+?>

--- a/plugin/user_profile/ajax.php
+++ b/plugin/user_profile/ajax.php
@@ -70,6 +70,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 MessageManager::send_message_simple($teacherId, $subject, $content);
             }
             $status = 'ok';
+        } elseif ($_POST['action'] === 'remind_agenda') {
+            $userId = (int) ($_POST['user_id'] ?? 0);
+            if ($userId) {
+                $subject = 'Relance agenda';
+                $content = "Bonjour, vous n'avez pas déclaré vos horaires de formation dans l'agenda. Merci de faire le nécessaire au plus vite. Cordialement";
+                $senderId = api_get_user_id();
+                MessageManager::send_message_simple($userId, $subject, $content, $senderId);
+            }
+            $status = 'ok';
         }
     }
     Security::clear_token();

--- a/plugin/user_profile/tracking.php
+++ b/plugin/user_profile/tracking.php
@@ -49,6 +49,26 @@ $(function(){
         }, "json");
     });
 
+    $(document).on("click", ".agenda-remind-btn", function(e){
+        e.preventDefault();
+        var $card = $(this).closest(".user-profile");
+        var userId = $card.data("user-id");
+        $.post("'.api_get_path(WEB_PLUGIN_PATH).'user_profile/ajax.php", {
+            action: "remind_agenda",
+            user_id: userId,
+            sec_token: userProfileToken
+        }, function(resp){
+            if (resp && resp.token) {
+                userProfileToken = resp.token;
+            }
+            if (resp && resp.status === \'ok\') {
+                alert("Message envoyé");
+            } else {
+                alert("Erreur lors de l\'envoi du message");
+            }
+        }, "json");
+    });
+
     $(document).on("change", ".per-page-select", function(){
         $("#per-page-form").submit();
     });
@@ -207,7 +227,7 @@ while ($user = Database::fetch_array($users)) {
 
     echo '<li class="list-group-item"><strong>'.get_lang('RegistrationDate').':</strong> '.Security::remove_XSS($registrationDate).'</li>';
     echo '<li class="list-group-item"><strong>'.get_lang('LastLogins').':</strong> '.Security::remove_XSS($lastLogin).'</li>';
-    echo '<li class="list-group-item"><strong>'.get_lang('Agenda').':</strong> '.$thisWeekBox.' | '.$nextWeekBox.'</li>';
+    echo '<li class="list-group-item"><strong>'.get_lang('Agenda').':</strong> '.$thisWeekBox.' | '.$nextWeekBox.' <button class="btn btn-warning btn-sm ml-2 agenda-remind-btn">Relancer</button></li>';
     echo '</ul>';
 
     // Time spent last week

--- a/plugin/user_profile/tracking.php
+++ b/plugin/user_profile/tracking.php
@@ -86,7 +86,7 @@ if (strlen($search) >= 3) {
 }
 
 // Fetch users to display (all or search-filtered)
-$userSql = "SELECT id, firstname, lastname, email, official_code, phone, registration_date, last_login FROM $tblUser";
+$userSql = "SELECT id, firstname, lastname, email, phone, registration_date, last_login FROM $tblUser";
 $where = '';
 if (!empty($searchResults)) {
     $ids = array_map('intval', array_column($searchResults, 'id'));
@@ -155,6 +155,20 @@ $end->modify('+6 days')->setTime(23, 59, 59);
 $startUtc = api_get_utc_datetime($start->format('Y-m-d H:i:s'));
 $endUtc = api_get_utc_datetime($end->format('Y-m-d H:i:s'));
 
+// Calculate current and next week ranges in UTC
+$weekStart = new DateTime('monday this week', new DateTimeZone('UTC'));
+$weekStart->setTime(0, 0, 0);
+$weekEnd = clone $weekStart;
+$weekEnd->modify('+6 days')->setTime(23, 59, 59);
+$nextWeekStart = clone $weekStart;
+$nextWeekStart->modify('+7 days');
+$nextWeekEnd = clone $weekEnd;
+$nextWeekEnd->modify('+7 days');
+$weekStartUtc = api_get_utc_datetime($weekStart->format('Y-m-d H:i:s'));
+$weekEndUtc = api_get_utc_datetime($weekEnd->format('Y-m-d H:i:s'));
+$nextWeekStartUtc = api_get_utc_datetime($nextWeekStart->format('Y-m-d H:i:s'));
+$nextWeekEndUtc = api_get_utc_datetime($nextWeekEnd->format('Y-m-d H:i:s'));
+
 while ($user = Database::fetch_array($users)) {
     $userId = (int) $user['id'];
     echo '<div class="col-md-6">';
@@ -165,7 +179,6 @@ while ($user = Database::fetch_array($users)) {
     echo '<div class="col-sm-8">';
     echo '<ul class="list-group list-group-flush">';
     echo '<li class="list-group-item"><strong>'.get_lang('Email').':</strong> '.Security::remove_XSS($user['email']).'</li>';
-    echo '<li class="list-group-item"><strong>'.get_lang('OfficialCode').':</strong> '.Security::remove_XSS($user['official_code']).'</li>';
     echo '<li class="list-group-item"><strong>'.get_lang('Phone').':</strong> '.Security::remove_XSS($user['phone']).'</li>';
     $registrationDate = (!empty($user['registration_date']) && $user['registration_date'] !== '0000-00-00 00:00:00')
         ? api_format_date($user['registration_date'], $dateDisplayFormat)
@@ -173,8 +186,28 @@ while ($user = Database::fetch_array($users)) {
     $lastLogin = (!empty($user['last_login']) && $user['last_login'] !== '0000-00-00 00:00:00')
         ? api_format_date($user['last_login'], $dateDisplayFormat)
         : '';
+
+    $tblCourseUser = Database::get_main_table(TABLE_MAIN_COURSE_USER);
+    $tblAgenda = Database::get_course_table(TABLE_AGENDA);
+    $courseRes = Database::query("SELECT DISTINCT c_id FROM $tblCourseUser WHERE user_id = $userId");
+    $courseIds = Database::store_result($courseRes);
+    $hasThisWeek = false;
+    $hasNextWeek = false;
+    if (!empty($courseIds)) {
+        $ids = implode(',', array_map('intval', array_column($courseIds, 'c_id')));
+        $sqlWeek = "SELECT 1 FROM $tblAgenda WHERE c_id IN ($ids) AND start_date >= '$weekStartUtc' AND start_date <= '$weekEndUtc' LIMIT 1";
+        $weekRes = Database::query($sqlWeek);
+        $hasThisWeek = Database::num_rows($weekRes) > 0;
+        $sqlNext = "SELECT 1 FROM $tblAgenda WHERE c_id IN ($ids) AND start_date >= '$nextWeekStartUtc' AND start_date <= '$nextWeekEndUtc' LIMIT 1";
+        $nextRes = Database::query($sqlNext);
+        $hasNextWeek = Database::num_rows($nextRes) > 0;
+    }
+    $thisWeekBox = '<span style="display:inline-block;width:12px;height:12px;background:'.($hasThisWeek ? '#28a745' : '#dc3545').'"></span>';
+    $nextWeekBox = '<span style="display:inline-block;width:12px;height:12px;background:'.($hasNextWeek ? '#28a745' : '#dc3545').'"></span>';
+
     echo '<li class="list-group-item"><strong>'.get_lang('RegistrationDate').':</strong> '.Security::remove_XSS($registrationDate).'</li>';
     echo '<li class="list-group-item"><strong>'.get_lang('LastLogins').':</strong> '.Security::remove_XSS($lastLogin).'</li>';
+    echo '<li class="list-group-item"><strong>'.get_lang('Agenda').':</strong> '.$thisWeekBox.' | '.$nextWeekBox.'</li>';
     echo '</ul>';
 
     // Time spent last week

--- a/plugin/user_profile/tracking.php
+++ b/plugin/user_profile/tracking.php
@@ -8,49 +8,143 @@ require_once api_get_path(LIBRARY_PATH).'sessionmanager.lib.php';
 require_once api_get_path(LIBRARY_PATH).'tracking.lib.php';
 
 global $htmlHeadXtra;
+$token = Security::get_token();
 $htmlHeadXtra[] = '<style>
     .user-profile.card {border:1px solid #eee;border-radius:4px;box-shadow:0 2px 4px rgba(0,0,0,0.05);margin-bottom:20px;}
     .user-profile .card-title {font-weight:bold;text-align:center;background:#f7f7f7;margin:0;padding:10px;}
     .list-group-item {border:0px solid #ddd;}
     .list-group-item.active{background:#337ab7;border-color:#337ab7;}
     .progress-circle{--p:0%;width:80px;height:80px;border-radius:50%;background:conic-gradient(#28a745 var(--p),#e9ecef 0);display:flex;align-items:center;justify-content:center;font-weight:bold;}
-    .time-block{background:#f8f9fa;border:1px solid #eee;border-radius:4px;padding:10px;text-align:center;margin-top:10px;margin-bottom:10px;}
+    .time-block{background:#f8f9fa;border:1px solid #eee;border-radius:4px;padding:10px;margin-top:10px;margin-bottom:10px;display:flex;justify-content:space-between;align-items:center;}
+    .user-profile-section {border:1px solid #eee;border-radius:4px;box-shadow:0 2px 4px rgba(0,0,0,0.05);padding:15px;margin-bottom:20px;}
+    .search-form {max-width:500px;margin:0 auto;}
+    .search-form .search-input{width:100%;margin:10px 0;}
 </style>';
+$htmlHeadXtra[] = '<script>
+var userProfileToken = "'.$token.'";
+$(function(){
+    $(document).on("click", ".warn-btn", function(e){
+        e.preventDefault();
+        var $card = $(this).closest(".user-profile");
+        var userId = $card.data("user-id");
+        var teacherId = $card.find(".teacher-select").val();
+        if(!teacherId){
+            alert("Veuillez sélectionner un formateur");
+            return;
+        }
+        $.post("'.api_get_path(WEB_PLUGIN_PATH).'user_profile/ajax.php", {
+            action: "warn",
+            user_id: userId,
+            teacher_id: teacherId,
+            sec_token: userProfileToken
+        }, function(resp){
+            if (resp && resp.token) {
+                userProfileToken = resp.token;
+            }
+            if (resp && resp.status === \'ok\') {
+                alert("Message envoyé");
+            } else {
+                alert("Erreur lors de l\'envoi du message");
+            }
+        }, "json");
+    });
+
+    $(document).on("change", ".per-page-select", function(){
+        $("#per-page-form").submit();
+    });
+});
+</script>';
 
 api_protect_admin_script();
 $plugin = UserProfilePlugin::create();
-
-$check = Security::check_token('post');
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && $check) {
-    if (isset($_POST['action']) && $_POST['action'] === 'toggle') {
-        $userId = (int) ($_POST['user_id'] ?? 0);
-        $fieldId = (int) ($_POST['field_id'] ?? 0);
-        $checked = (int) ($_POST['checked'] ?? 0);
-        $tblValue = Database::get_main_table(UserProfilePlugin::TABLE_VALUE);
-        $where = ['user_id = ? AND field_id = ?' => [$userId, $fieldId]];
-        $exists = Database::select('id', $tblValue, ['where' => $where], 'first');
-        if ($exists) {
-            Database::update($tblValue, ['checked' => $checked], $where);
-        } else {
-            Database::insert($tblValue, [
-                'user_id' => $userId,
-                'field_id' => $fieldId,
-                'value' => '',
-                'checked' => $checked,
-            ]);
-        }
-    }
-    Security::clear_token();
-    header('Content-Type: application/json');
-    echo json_encode(['token' => Security::get_token()]);
-    exit;
-}
-$token = Security::get_token();
+$urlId = api_get_current_access_url_id();
 
 $tblUser = Database::get_main_table(TABLE_MAIN_USER);
-$users = Database::query("SELECT id, firstname, lastname, email, official_code, phone, registration_date, last_login FROM $tblUser ORDER BY lastname, firstname");
+
+$dateDisplayFormat = '%A %d %B %Y';
+
+$search = trim($_GET['search'] ?? '');
+$perPageOptions = [10, 20, 30, 50, 'all'];
+$perPage = $_GET['per_page'] ?? 10;
+if (!in_array($perPage, $perPageOptions, true)) {
+    $perPage = 10;
+}
+$page = max(1, (int) ($_GET['page'] ?? 1));
+// Collect IDs matching search if any
+$searchResults = [];
+if (strlen($search) >= 3) {
+    $tblUrl = Database::get_main_table(TABLE_MAIN_ACCESS_URL_REL_USER);
+    $escaped = Database::escape_string($search);
+    $condition = "(u.firstname LIKE '%$escaped%' OR u.lastname LIKE '%$escaped%')";
+    if (api_is_multiple_url_enabled()) {
+        $sql = "SELECT u.id FROM $tblUser u INNER JOIN $tblUrl url ON (u.id = url.user_id) WHERE url.access_url_id = $urlId AND $condition";
+    } else {
+        $sql = "SELECT id FROM $tblUser u WHERE $condition";
+    }
+    $res = Database::query($sql);
+    $searchResults = Database::store_result($res);
+}
+
+// Fetch users to display (all or search-filtered)
+$userSql = "SELECT id, firstname, lastname, email, official_code, phone, registration_date, last_login FROM $tblUser";
+$where = '';
+if (!empty($searchResults)) {
+    $ids = array_map('intval', array_column($searchResults, 'id'));
+    $where = " WHERE id IN (".implode(',', $ids).")";
+} elseif ($search !== '' && strlen($search) >= 3) {
+    // Search performed but no users found
+    $where = " WHERE 0";
+}
+$userSql .= $where;
+
+$countSql = "SELECT COUNT(*) AS count FROM $tblUser".$where;
+$countRes = Database::query($countSql);
+$countRow = Database::fetch_array($countRes);
+$totalCount = (int) $countRow['count'];
+
+if ($perPage !== 'all') {
+    $totalPages = (int) ceil($totalCount / (int) $perPage);
+    $page = min($page, max($totalPages, 1));
+    $offset = ((int) $perPage) * ($page - 1);
+    $userSql .= " ORDER BY lastname, firstname LIMIT $perPage OFFSET $offset";
+} else {
+    $totalPages = 1;
+    $userSql .= " ORDER BY lastname, firstname";
+}
+$users = Database::query($userSql);
+// Preload teachers for selection list
+$teachersRes = Database::query("SELECT id, firstname, lastname FROM $tblUser WHERE status = ".COURSEMANAGER." ORDER BY lastname, firstname");
+$teachers = Database::store_result($teachersRes);
 
 Display::display_header(get_lang('UserTracking', 'user_profile'));
+
+echo '<div class="user-profile-section text-center">';
+echo Display::page_subheader(get_lang('SearchUser', 'user_profile'));
+echo '<div class="mb-3">';
+echo '<form method="get" class="search-form">';
+echo '<input type="text" name="search" value="'.Security::remove_XSS($search).'" class="form-control mb-2 search-input" placeholder="'.get_lang('SearchUser', 'user_profile').'">';
+echo '<input type="hidden" name="per_page" value="'.Security::remove_XSS($perPage).'">';
+echo '<button type="submit" class="btn btn-primary">'.get_lang('Search').'</button>';
+echo '</form>';
+echo '</div>';
+if ($search !== '' && strlen($search) >= 3 && empty($searchResults)) {
+    echo Display::return_message(get_lang('NoResults'), 'warning');
+}
+echo '</div>';
+
+echo '<div class="mb-3" style="max-width:80px;">';
+echo '<form method="get" id="per-page-form">';
+echo '<input type="hidden" name="search" value="'.Security::remove_XSS($search).'">';
+echo '<select name="per_page" class="form-control per-page-select">';
+foreach ($perPageOptions as $opt) {
+    $sel = ($opt == $perPage) ? ' selected' : '';
+    $label = ($opt === 'all') ? get_lang('All') : (string) $opt;
+    echo '<option value="'.Security::remove_XSS($opt).'"'.$sel.'>'.$label.'</option>';
+}
+echo '</select>';
+echo '</form>';
+echo '</div>';
+echo '<br>';
 
 echo '<div class="row">';
 // Calculate last week's start (Monday) and end (Sunday) in UTC
@@ -64,7 +158,7 @@ $endUtc = api_get_utc_datetime($end->format('Y-m-d H:i:s'));
 while ($user = Database::fetch_array($users)) {
     $userId = (int) $user['id'];
     echo '<div class="col-md-6">';
-    echo '<div class="card user-profile">';
+    echo '<div class="card user-profile" data-user-id="'.$userId.'">';
     echo '<div class="card-title"><strong>'.Security::remove_XSS($user['firstname'].' '.$user['lastname']).'</strong></div>';
     echo '<div class="card-body"><div class="row">';
 
@@ -73,8 +167,14 @@ while ($user = Database::fetch_array($users)) {
     echo '<li class="list-group-item"><strong>'.get_lang('Email').':</strong> '.Security::remove_XSS($user['email']).'</li>';
     echo '<li class="list-group-item"><strong>'.get_lang('OfficialCode').':</strong> '.Security::remove_XSS($user['official_code']).'</li>';
     echo '<li class="list-group-item"><strong>'.get_lang('Phone').':</strong> '.Security::remove_XSS($user['phone']).'</li>';
-    echo '<li class="list-group-item"><strong>'.get_lang('RegistrationDate').':</strong> '.Security::remove_XSS($user['registration_date']).'</li>';
-    echo '<li class="list-group-item"><strong>'.get_lang('LastLogins').':</strong> '.Security::remove_XSS($user['last_login']).'</li>';
+    $registrationDate = (!empty($user['registration_date']) && $user['registration_date'] !== '0000-00-00 00:00:00')
+        ? api_format_date($user['registration_date'], $dateDisplayFormat)
+        : '';
+    $lastLogin = (!empty($user['last_login']) && $user['last_login'] !== '0000-00-00 00:00:00')
+        ? api_format_date($user['last_login'], $dateDisplayFormat)
+        : '';
+    echo '<li class="list-group-item"><strong>'.get_lang('RegistrationDate').':</strong> '.Security::remove_XSS($registrationDate).'</li>';
+    echo '<li class="list-group-item"><strong>'.get_lang('LastLogins').':</strong> '.Security::remove_XSS($lastLogin).'</li>';
     echo '</ul>';
 
     // Time spent last week
@@ -90,7 +190,11 @@ while ($user = Database::fetch_array($users)) {
     $rowTime = Database::fetch_array($resTime, 'ASSOC');
     $timeSpent = (int) $rowTime['time'];
     $timeLabel = get_lang('TimeSpentLastWeek', 'user_profile');
-    echo '<div class="time-block"><strong>'.Security::remove_XSS($timeLabel).':</strong> '.Security::remove_XSS(gmdate('H:i:s', $timeSpent)).'</div>';
+    $detailsUrl = api_get_path(WEB_CODE_PATH).'mySpace/myStudents.php?student='.$userId;
+    $profileUrl = api_get_path(WEB_PLUGIN_PATH).'user_profile/view.php?id='.$userId;
+    echo '<div class="time-block">';
+    echo '<span><strong>'.Security::remove_XSS($timeLabel).':</strong> '.Security::remove_XSS(gmdate('H:i:s', $timeSpent)).'</span>';
+    echo '</div>';
     echo '</div>'; // col-sm-8
 
     // Average progress circle
@@ -122,7 +226,6 @@ while ($user = Database::fetch_array($users)) {
     $tblField = Database::get_main_table(UserProfilePlugin::TABLE_FIELD);
     $tblValue = Database::get_main_table(UserProfilePlugin::TABLE_VALUE);
     $tblCat = Database::get_main_table(UserProfilePlugin::TABLE_CATEGORY);
-    $urlId = api_get_current_access_url_id();
     $sql = "SELECT f.id, f.name, f.field_type, f.category_id, v.value, COALESCE(v.checked,0) AS checked, c.name AS category_name
             FROM $tblField f
             LEFT JOIN $tblValue v ON (f.id = v.field_id AND v.user_id = $userId)
@@ -143,47 +246,67 @@ while ($user = Database::fetch_array($users)) {
             echo '<div class="table-responsive"><table class="table table-hover mb-0">';
             echo '<thead><tr><th></th><th class="text-right">'.get_lang('Completed', 'user_profile').'</th></tr></thead><tbody>';
             foreach ($cat['fields'] as $field) {
-                $val = $field['value'];
-                if ($field['field_type'] === 'date' && !empty($val)) {
-                    $val = api_format_date($val, DATE_FORMAT_LONG);
+                $rawVal = $field['value'];
+                $val = '';
+                if ($field['field_type'] === 'date' && !empty($rawVal)) {
+                    $formatted = api_format_date($rawVal, $dateDisplayFormat);
+                    if (empty($field['checked']) && strtotime($rawVal) < time()) {
+                        $val = '<span class="text-danger">'.Security::remove_XSS($formatted).' <em class="fa fa-exclamation-triangle"></em></span>';
+                    } else {
+                        $val = Security::remove_XSS($formatted);
+                    }
+                } else {
+                    $val = Security::remove_XSS($rawVal);
                 }
-                echo '<tr>';
                 $checkedAttr = !empty($field['checked']) ? ' checked' : '';
                 echo '<tr>';
-echo '<td>'.Security::remove_XSS($field['name']);
-if (!empty($val)) {
-    echo ' : ' . Security::remove_XSS($val);
-}
-echo '</td>';
-echo '<td class="text-right"><input type="checkbox" class="track-check" data-user="'.$userId.'" data-field="'.$field['id'].'"'.$checkedAttr.'></td>';
-echo '</tr>';
-
+                echo '<td>'.Security::remove_XSS($field['name']);
+                if ($val !== '') {
+                    echo ' : '.$val;
+                }
+                echo '</td>';
+                echo '<td class="text-right"><input type="checkbox" disabled'.$checkedAttr.'></td>';
                 echo '</tr>';
             }
             echo '</tbody></table></div>';
             echo '</div>';
         }
-        echo '</ul>';
     }
+    // Selection list of teachers
+    if (!empty($teachers)) {
+        echo '<div class="mt-3">';
+        echo '<label>'.get_lang('Teacher').'</label>';
+        echo '<select class="form-control teacher-select">';
+        // Default empty option so no teacher is pre-selected
+        echo '<option value=""></option>';
+        foreach ($teachers as $teacher) {
+            $fullName = $teacher['firstname'].' '.$teacher['lastname'];
+            echo '<option value="'.((int) $teacher['id']).'">'.Security::remove_XSS($fullName).'</option>';
+        }
+        echo '</select>';
+        echo '</div>';
+    }
+    echo '<div class="text-center mt-3">';
+    echo '<a class="btn btn-danger" href="'.Security::remove_XSS($detailsUrl).'">Suivi</a>';
+    echo '<a class="btn btn-primary ml-2" href="'.Security::remove_XSS($profileUrl).'">'.get_lang('UserProfile').'</a>';
+    echo '<button class="btn btn-success ml-2 warn-btn">Avertir</button>';
+    echo '</div>';
     echo '</div>'; // card-body
     echo '</div></div>';
 }
 echo '</div>';
 
-echo "<script>
-    var token = '$token';
-    $(function(){
-        $('.track-check').on('change', function(){
-            var el = $(this);
-            $.post('".api_get_self()."', {
-                sec_token: token,
-                action: 'toggle',
-                user_id: el.data('user'),
-                field_id: el.data('field'),
-                checked: el.is(':checked') ? 1 : 0
-            }, function(resp){ if(resp.token){ token = resp.token; } }, 'json');
-        });
-    });
-</script>";
+if ($totalPages > 1) {
+    echo '<nav aria-label="User pagination"><ul class="pagination">';
+    for ($i = 1; $i <= $totalPages; $i++) {
+        $active = $i == $page ? ' active' : '';
+        $url = '?page='.$i.'&per_page='.urlencode((string) $perPage);
+        if ($search !== '') {
+            $url .= '&search='.urlencode($search);
+        }
+        echo '<li class="page-item'.$active.'"><a class="page-link" href="'.$url.'">'.$i.'</a></li>';
+    }
+    echo '</ul></nav>';
+}
 
 Display::display_footer();


### PR DESCRIPTION
## Summary
- show user profile categories and read-only tracking checkboxes on student page
- color overdue profile dates red with an alert when their box is unchecked, otherwise green
- flag overdue profile dates in student profile section with red text and warning icon
- add configurable pagination with per-page selector and page navigation on tracking page
- place per-page selector between search form and user cards and auto-refresh results on change
- fix duplicate ORDER BY clause in tracking pagination query
- center tracking search section and add line break after per-page dropdown
- format all tracking page dates in long French style (e.g., "Lundi 04 Août 2025")
- remove alert icon next to “Fiche utilisateur” title when checkboxes remain unchecked

## Testing
- `php -l main/inc/lib/MyStudents.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894e9c65e00832ba99dba9b7dd7d9be