### PR TITLE
V2 de user profile après ajout manuel précédents

### DIFF
--- a/main/inc/lib/MyStudents.php
+++ b/main/inc/lib/MyStudents.php
@@ -60,6 +60,388 @@ class MyStudents
         return $table->toHtml();
     }
 
+    public static function getAgendaStatusBoxes(int $studentId): array
+    {
+        $weekStart = new DateTime('monday this week', new DateTimeZone('UTC'));
+        $weekStart->setTime(0, 0, 0);
+        $weekEnd = clone $weekStart;
+        $weekEnd->modify('+6 days')->setTime(23, 59, 59);
+        $nextWeekStart = clone $weekStart;
+        $nextWeekStart->modify('+7 days');
+        $nextWeekEnd = clone $weekEnd;
+        $nextWeekEnd->modify('+7 days');
+        $weekStartUtc = api_get_utc_datetime($weekStart->format('Y-m-d H:i:s'));
+        $weekEndUtc = api_get_utc_datetime($weekEnd->format('Y-m-d H:i:s'));
+        $nextWeekStartUtc = api_get_utc_datetime($nextWeekStart->format('Y-m-d H:i:s'));
+        $nextWeekEndUtc = api_get_utc_datetime($nextWeekEnd->format('Y-m-d H:i:s'));
+        $tblCourseUser = Database::get_main_table(TABLE_MAIN_COURSE_USER);
+        $tblAgenda = Database::get_course_table(TABLE_AGENDA);
+        $courseRes = Database::query("SELECT DISTINCT c_id FROM $tblCourseUser WHERE user_id = $studentId");
+        $courseIds = Database::store_result($courseRes);
+        $hasThisWeek = false;
+        $hasNextWeek = false;
+        if (!empty($courseIds)) {
+            $ids = implode(',', array_map('intval', array_column($courseIds, 'c_id')));
+            $sqlWeek = "SELECT 1 FROM $tblAgenda WHERE c_id IN ($ids) AND start_date >= '$weekStartUtc' AND start_date <= '$weekEndUtc' LIMIT 1";
+            $weekRes = Database::query($sqlWeek);
+            $hasThisWeek = Database::num_rows($weekRes) > 0;
+            $sqlNext = "SELECT 1 FROM $tblAgenda WHERE c_id IN ($ids) AND start_date >= '$nextWeekStartUtc' AND start_date <= '$nextWeekEndUtc' LIMIT 1";
+            $nextRes = Database::query($sqlNext);
+            $hasNextWeek = Database::num_rows($nextRes) > 0;
+        }
+        $thisWeekBox = '<span style="display:inline-block;width:12px;height:12px;background:'.($hasThisWeek ? '#28a745' : '#dc3545').'"></span>';
+        $nextWeekBox = '<span style="display:inline-block;width:12px;height:12px;background:'.($hasNextWeek ? '#28a745' : '#dc3545').'"></span>';
+
+        return [$thisWeekBox, $nextWeekBox];
+    }
+
+    public static function getBlockForUserProfile(int $studentId, bool $editable = true): string
+    {
+        $enabled = api_get_configuration_value('plugin_user_profile_enabled');
+        $installed = AppPlugin::getInstance()->isInstalled('user_profile');
+        if (!$enabled || !$installed) {
+            return '';
+        }
+
+        require_once api_get_path(SYS_PLUGIN_PATH).'user_profile/config.php';
+        require_once api_get_path(SYS_PLUGIN_PATH).'user_profile/UserProfilePlugin.php';
+        $plugin = UserProfilePlugin::create();
+
+        $categories = $plugin->getCategories();
+        // Only keep fields that are marked as tracked in the admin (include_tracking = 1)
+        $fields = array_filter(
+            $plugin->getFields(),
+            static function (array $field): bool {
+                return !empty($field['include_tracking']);
+            }
+        );
+        $values = $plugin->getUserValues($studentId);
+
+        [$thisWeekBox, $nextWeekBox] = self::getAgendaStatusBoxes($studentId);
+        $agendaRow = '<strong>'.get_lang('Agenda').':</strong> '.$thisWeekBox.' | '.$nextWeekBox;
+        if ($editable) {
+            $agendaRow .= ' <button class="btn btn-warning ml-2 agenda-remind-btn" data-user="'.$studentId.'">Relancer</button>';
+        }
+        $agendaCard = '<div class="card user-profile mb-3"><div class="card-body text-center">'.$agendaRow.'</div></div>';
+        $linkCard = '';
+        if ($editable) {
+            $viewUrl = api_get_path(WEB_PLUGIN_PATH).'user_profile/view.php?id='.$studentId;
+            $viewBtn = '<a href="'.$viewUrl.'" class="btn btn-primary">'.get_lang('UserProfile', 'user_profile').'</a>';
+            $linkCard = '<div class="card user-profile mb-3"><div class="card-body text-center">'.$viewBtn.'</div></div>';
+        }
+
+        $byCat = [];
+        foreach ($fields as $field) {
+            $byCat[$field['category_id']][] = $field;
+        }
+
+        $catHtml = '';
+        foreach ($categories as $cat) {
+            if (empty($byCat[$cat['id']])) {
+                continue;
+            }
+
+            $label = Security::remove_XSS(UserProfilePlugin::getCategoryLabel($cat));
+            $catHtml .= '<div class="card user-profile mb-3">';
+            $catHtml .= '<div class="card-header text-center" style="background-color:#337ab7;color:#fff;padding:10px;"><strong>'
+                .$label.'</strong></div>';
+            $catHtml .= '<ul class="list-group list-group-flush">';
+            foreach ($byCat[$cat['id']] as $field) {
+                $valueData = $values[$field['id']] ?? ['value' => '', 'checked' => 0];
+                $rawValue = $valueData['value'];
+                $checked = !empty($valueData['checked']);
+                $valueHtml = '';
+                if ($field['field_type'] === 'date' && !empty($rawValue)) {
+                    $formatted = api_format_date($rawValue, DATE_FORMAT_SHORT);
+                    $safeFormatted = Security::remove_XSS($formatted);
+                    $isPast = strtotime($rawValue) < time();
+                    $class = 'text-success';
+                    $icon = '';
+                    if ($isPast && !$checked) {
+                        $class = 'text-danger';
+                        $icon = ' <em class="fa fa-exclamation-triangle"></em>';
+                    }
+                    $valueHtml = '<span class="profile-value profile-value-date '.$class.'" '
+                        .'data-formatted="'.$safeFormatted.'" data-overdue="'.($isPast ? 1 : 0).'">'
+                        .$safeFormatted.$icon.'</span>';
+                } else {
+                    $valueHtml = '<span class="profile-value">'
+                        .Security::remove_XSS($rawValue).'</span>';
+                }
+                $checkedAttr = $checked ? ' checked' : '';
+                $inputAttr = $editable ? 'class="profile-check" data-user="'.$studentId.'" data-field="'.$field['id'].'"' : 'disabled';
+                $catHtml .= '<li class="list-group-item"><input type="checkbox" '.$inputAttr.$checkedAttr.'> <strong>'
+                    .Security::remove_XSS($field['name']).'</strong>';
+                if ($rawValue !== '') {
+                    $catHtml .= ': '.$valueHtml;
+                }
+                if ($editable) {
+                    $catHtml .= ' <span class="profile-status"></span>';
+                }
+                $catHtml .= '</li>';
+            }
+            $catHtml .= '</ul>';
+            $catHtml .= '</div>';
+        }
+
+        if ($editable && $linkCard !== '') {
+            $topCards = '<div class="row"><div class="col-md-6">'.$agendaCard.'</div><div class="col-md-6">'.$linkCard.'</div></div>';
+            $content = $topCards;
+        } else {
+            $content = $agendaCard;
+        }
+        if ($catHtml !== '') {
+            $content .= $catHtml;
+        }
+        if ($editable) {
+            $token = Security::get_existing_token();
+            $url = api_get_path(WEB_PLUGIN_PATH).'user_profile/ajax.php';
+            $script = <<<JS
+<script>
+var profileToken = '$token';
+$(function(){
+    $('.profile-check').on('change', function(){
+        var el = $(this);
+        var li = el.closest('li');
+        $.post('$url', {
+            sec_token: profileToken,
+            action: 'toggle',
+            user_id: el.data('user'),
+            field_id: el.data('field'),
+            checked: el.is(':checked') ? 1 : 0
+        }, function(resp){
+            if(resp.token){ profileToken = resp.token; }
+            var span = li.find('.profile-value-date');
+            if(span.length){
+                var formatted = span.data('formatted');
+                var overdue = parseInt(span.data('overdue'),10) === 1;
+                if(overdue && !el.is(':checked')){
+                    span.attr('class','profile-value profile-value-date text-danger').html(formatted+' <em class="fa fa-exclamation-triangle"></em>');
+                } else {
+                    span.attr('class','profile-value profile-value-date text-success').text(formatted);
+                }
+            }
+            li.find('.profile-status').text('ok').show().fadeOut(2000, function(){
+                $(this).text('');
+                $(this).show();
+            });
+        }, 'json');
+    });
+    $('.agenda-remind-btn').on('click', function(e){
+        e.preventDefault();
+        var btn = $(this);
+        $.post('$url', {
+            sec_token: profileToken,
+            action: 'remind_agenda',
+            user_id: btn.data('user')
+        }, function(resp){
+            if(resp.token){ profileToken = resp.token; }
+            if(resp.status == 'ok'){
+                alert('Message envoyé');
+            } else {
+                alert('Erreur lors de l\'envoi du message');
+            }
+        }, 'json');
+    });
+});
+</script>
+JS;
+            $content .= $script;
+        }
+
+        $title = get_lang('UserProfile', 'user_profile');
+
+        return Display::panelCollapse(
+            $title,
+            $content,
+            'panel-user-profile',
+            [],
+            'accordion-user-profile',
+            'collapse-user-profile',
+            false
+        );
+    }
+
+    public static function getBlockForSynthesis(int $studentId, bool $forExport = false): string
+    {
+        $orderCondition = null;
+        if (api_get_configuration_value('session_list_order')) {
+            $orderCondition = ' ORDER BY s.position ASC';
+        }
+        $sessions = SessionManager::getSessionsFollowedByUser(
+            $studentId,
+            null,
+            null,
+            null,
+            false,
+            false,
+            false,
+            $orderCondition
+        );
+        $sessionProgressTitle = get_lang('synthesis');
+        $sessionProgressHeading = '<h3 class="panel-title text-center"><strong>'.$sessionProgressTitle.'</strong></h3>';
+        $sessionProgressList = [];
+        $totalSessionsProgress = 0;
+        foreach ($sessions as $sessionItem) {
+            $courses = SessionManager::get_course_list_by_session_id($sessionItem['id']);
+            $courseProgressSum = 0;
+            $courseCount = 0;
+            foreach ($courses as $courseItem) {
+                $courseInfoItem = api_get_course_info_by_id($courseItem['real_id']);
+                $courseCodeItem = $courseInfoItem['code'];
+                if (CourseManager::is_user_subscribed_in_course($studentId, $courseCodeItem, true, $sessionItem['id'])) {
+                    $progressValue = Tracking::get_avg_student_progress(
+                        $studentId,
+                        $courseCodeItem,
+                        [],
+                        $sessionItem['id']
+                    );
+                    if (is_numeric($progressValue)) {
+                        $courseProgressSum += $progressValue;
+                    }
+                    $courseCount++;
+                }
+            }
+            $progress = $courseCount > 0 ? round($courseProgressSum / $courseCount, 2) : 0;
+            $sessionProgressList[] = [
+                'name' => $sessionItem['name'],
+                'progress' => $progress,
+            ];
+            $totalSessionsProgress += $progress;
+        }
+        $avgSessionsProgress = !empty($sessionProgressList) ? round($totalSessionsProgress / count($sessionProgressList), 2) : 0;
+
+        $aLastWeek = get_last_week();
+        $startWeek = date('Y-m-d', $aLastWeek[0]);
+        $endWeek = date('Y-m-d', $aLastWeek[6]);
+        $report = Tracking::generateReport('time_report', [$studentId], $startWeek, $endWeek);
+        $timeSeconds = 0;
+        foreach ($report['rows'] as $reportRow) {
+            $timeParts = explode(':', $reportRow[6]);
+            if (count($timeParts) === 3) {
+                [$hours, $minutes, $seconds] = array_map('intval', $timeParts);
+                $timeSeconds += ($hours * 3600) + ($minutes * 60) + $seconds;
+            }
+        }
+        $timeSpentLastWeek = api_time_to_hms($timeSeconds);
+        $detailsUrl = api_get_path(WEB_CODE_PATH)
+            .'mySpace/time_report_last_week.php?student='.$studentId
+            .'&start='.$startWeek.'&end='.$endWeek;
+        $timeContent  = '<div class="text-center">';
+        $timeContent .= Display::return_icon('clock.png', get_lang('TimeSpentLastWeek'), [], ICON_SIZE_MEDIUM);
+        $timeContent .= '<div>'.$timeSpentLastWeek.'</div>';
+        if (!$forExport) {
+            $timeContent .= '<div>&nbsp;</div>';
+            $timeContent .= '<div><a href="'.$detailsUrl.'" onclick="window.open(this.href, \'timeReportDetails\', \'width=800,height=600,scrollbars=yes\'); return false;">'.get_lang('Details').'</a></div>';
+            $timeContent .= '<div>&nbsp;</div>';
+            $timeContent .= '<div><a href="'.$detailsUrl.'&export=pdf">'.Display::return_icon('pdf.png', get_lang('ExportPDF'), [], ICON_SIZE_MEDIUM).'</a> '
+                .'<a href="'.$detailsUrl.'&export=xls">'.Display::return_icon('export_excel.png', get_lang('ExportAsXLS'), [], ICON_SIZE_MEDIUM).'</a></div>';
+        }
+        $timeContent .= '</div>';
+        $timePanel = Display::panel($timeContent, get_lang('TimeSpentInCoursesLastWeek'));
+
+        if ($forExport) {
+            $avgProgressContent = '<div class="text-center"><div>'.$avgSessionsProgress.'%</div></div>';
+        } else {
+            $avgProgressContent  = '<div class="text-center">';
+            $avgProgressContent .= '<div id="avg-sessions-progress" class="easypiechart" data-percent="'.$avgSessionsProgress.'">';
+            $avgProgressContent .= '<span class="percent">'.$avgSessionsProgress.'%</span>';
+            $avgProgressContent .= '</div>';
+            $avgProgressContent .= '</div>';
+            $avgProgressContent .= "<script>\n $(function() {\n $('#avg-sessions-progress').easyPieChart({\n scaleColor: false,\n lineWidth: 8,\n barColor: '#3ba557',\n trackColor: '#f2f2f2'\n});\n});\n</script>";
+        }
+        $avgProgressPanel = Display::panel($avgProgressContent, get_lang('AverageProgressInSessions'));
+
+        $sessionBars = '';
+        foreach ($sessionProgressList as $item) {
+            $sessionBars .= '<p>'.Security::remove_XSS($item['name']).'</p>';
+            $sessionBars .= '<div class="progress">';
+            $sessionBars .= '<div class="progress-bar progress-bar-success" role="progressbar" style="width: '.$item['progress'].'%">'.$item['progress'].'%</div>';
+            $sessionBars .= '</div>';
+        }
+        if ($forExport) {
+            $sessionBarsPanel = Display::panel(
+                $sessionBars,
+                get_lang('ProgressionInSessions')
+            );
+        } else {
+            $sessionBarsPanel = Display::panelCollapse(
+                get_lang('ProgressionInSessions'),
+                $sessionBars,
+                'panel-session-progress',
+                [],
+                'accordion-session-progress',
+                'collapse-session-progress',
+                false,
+                true
+            );
+        }
+
+        $weeksToShow = 52;
+        $currentMonday = strtotime('monday this week');
+        $weekData = [];
+        for ($i = 1; $i <= $weeksToShow; $i++) {
+            $weekStart = strtotime('-'.$i.' week', $currentMonday);
+            $weekEnd = $weekStart + (6 * 86400);
+            $startDate = date('Y-m-d', $weekStart);
+            $endDate = date('Y-m-d', $weekEnd);
+            $reportWeek = Tracking::generateReport('time_report', [$studentId], $startDate, $endDate);
+            $weekSeconds = 0;
+            foreach ($reportWeek['rows'] as $reportRow) {
+                $parts = explode(':', $reportRow[6]);
+                if (count($parts) === 3) {
+                    [$h, $m, $s] = array_map('intval', $parts);
+                    $weekSeconds += ($h * 3600) + ($m * 60) + $s;
+                }
+            }
+            $label = date('Y', $weekStart).' - '.date('W', $weekStart);
+            $weekData[] = [
+                'label' => $label,
+                'time'  => api_time_to_hms($weekSeconds),
+            ];
+        }
+        $tablesHtml = '<div class="row">';
+        $tablesCount = 4;
+        $weeksPerTable = (int) ceil($weeksToShow / $tablesCount);
+        $index = 0;
+        for ($table = 0; $table < $tablesCount; $table++) {
+            $tableHtml  = '<table class="table table-bordered table-condensed">';
+            $tableHtml .= '<thead><tr><th>'.get_lang('Week').'</th><th>'.get_lang('LatencyTimeSpent').'</th></tr></thead><tbody>';
+            for ($j = 0; $j < $weeksPerTable && $index < count($weekData); $j++, $index++) {
+                $label = Security::remove_XSS($weekData[$index]['label']);
+                $time  = $weekData[$index]['time'];
+                $tableHtml .= '<tr><th class="text-center">'.$label.'</th><td class="text-right">'.$time.'</td></tr>';
+            }
+            $tableHtml .= '</tbody></table>';
+            $tablesHtml .= '<div class="col-md-3">'.$tableHtml.'</div>';
+        }
+        $tablesHtml .= '</div>';
+        if ($forExport) {
+            $weeklySummaryPanel = Display::panel(
+                $tablesHtml,
+                get_lang('WeeklyTimeSummary')
+            );
+        } else {
+            $weeklySummaryPanel = Display::panelCollapse(
+                get_lang('WeeklyTimeSummary'),
+                $tablesHtml,
+                'panel-weekly-summary',
+                [],
+                'accordion-weekly-summary',
+                'collapse-weekly-summary',
+                false
+            );
+        }
+        $sessionProgressHtml  = '<div class="row session-progress-section" style="display:flex;flex-wrap:wrap;align-items:stretch;">';
+        $sessionProgressHtml .= '<div class="col-md-6 text-center" style="display:flex;"><div style="flex:1;">'.$avgProgressPanel.'</div></div>';
+        $sessionProgressHtml .= '<div class="col-md-6" style="display:flex;"><div style="flex:1;">'.$timePanel.'</div></div>';
+        $sessionProgressHtml .= '</div>';
+        $sessionProgressHtml .= $sessionBarsPanel;
+        $sessionProgressHtml .= $weeklySummaryPanel;
+
+        return Display::panel($sessionProgressHtml, '', '', 'default', $sessionProgressHeading);
+    }
+
     public static function getBlockForSkills(int $studentId, int $courseId, int $sessionId): string
     {
         $allowAll = api_get_configuration_value('allow_teacher_access_student_skills');

--- a/main/mySpace/myStudents.php
+++ b/main/mySpace/myStudents.php
@@ -1366,6 +1366,11 @@ if (api_get_configuration_value('improve_tracking_in_mystudent_php')) {
     echo Display::panel($sessionProgressHtml, '', '', 'default', $sessionProgressHeading);
 }
 
+$profileBlock = MyStudents::getBlockForUserProfile($student_id);
+if (!empty($profileBlock)) {
+    echo $profileBlock;
+    echo '<br /><br />';
+}
 echo MyStudents::getBlockForSkills(
     $student_id,
     $courseInfo ? $courseInfo['real_id'] : 0,

--- a/main/mySpace/time_report_last_week.php
+++ b/main/mySpace/time_report_last_week.php
@@ -38,7 +38,51 @@ if ($export === 'xls') {
     exit;
 }
 
-$html = Export::convert_array_to_html($rows);
+$table = '';
+if (!empty($rows)) {
+    $headers = array_shift($rows);
+    $colors = ['#cce5ff', '#ffe5b4'];
+    $colorIndex = 0;
+
+    // Group entries by starting date (column index 4)
+    $grouped = [];
+    foreach ($rows as $row) {
+        $dateKey = substr($row[4], 0, 10);
+        $grouped[$dateKey][] = $row;
+    }
+
+    $table = '<table class="data_table" style="border-collapse:collapse;border:1px solid #ccc;">';
+    $table .= '<tr>';
+    foreach ($headers as $header) {
+        $table .= '<th style="border:1px solid #ccc;padding-left:5px;">'.htmlspecialchars($header).'</th>';
+    }
+    $table .= '</tr>';
+
+    foreach ($grouped as $day => $dayRows) {
+        $totalSeconds = 0;
+        foreach ($dayRows as $row) {
+            $table .= '<tr style="background-color:'.$colors[$colorIndex].'">';
+            foreach ($row as $cell) {
+                $table .= '<td style="border:1px solid #ccc;padding-left:5px;">'.htmlspecialchars($cell).'</td>';
+            }
+            $table .= '</tr>';
+
+            $parts = explode(':', $row[6]);
+            if (count($parts) === 3) {
+                $totalSeconds += ($parts[0] * 3600) + ($parts[1] * 60) + $parts[2];
+            }
+        }
+
+        $table .= '<tr style="background-color:'.$colors[$colorIndex].';font-weight:bold;">'
+            .'<td colspan="'.(count($headers) - 1).'" style="text-align:right;border:1px solid #ccc;padding-left:5px;">'.get_lang('Total').'</td>'
+            .'<td style="border:1px solid #ccc;padding-left:5px;">'.gmdate('H:i:s', $totalSeconds).'</td>'
+            .'</tr>';
+
+        $colorIndex = 1 - $colorIndex;
+    }
+
+    $table .= '</table>';
+}
 
 $nameTools = get_lang('TimeReport');
 Display::display_header($nameTools);
@@ -50,5 +94,5 @@ echo '<div>'
     .'<a href="'.$baseUrl.'&export=xls">'
     .Display::return_icon('export_excel.png', get_lang('ExportAsXLS'), [], ICON_SIZE_MEDIUM)
     .'</a></div>';
-echo $html;
+echo $table;
 Display::display_footer();

--- a/plugin/user_profile/UserProfilePlugin.php
+++ b/plugin/user_profile/UserProfilePlugin.php
@@ -192,7 +192,9 @@ class UserProfilePlugin extends Plugin implements HookPluginInterface
                     $form->addText($name, $field['name'], false);
                 }
                 if (isset($values[$field['id']])) {
-                    $form->setDefaults([$name => $values[$field['id']]]);
+                    $form->setDefaults([
+                        $name => $values[$field['id']]['value'],
+                    ]);
                 }
             }
         }
@@ -216,7 +218,7 @@ class UserProfilePlugin extends Plugin implements HookPluginInterface
                     'user_id' => $userId,
                     'field_id' => $field['id'],
                     'value' => $value,
-                    'include_tracking' => 0,
+                    'checked' => 0,
                 ]);
             }
         }
@@ -230,7 +232,10 @@ class UserProfilePlugin extends Plugin implements HookPluginInterface
         ]);
         $values = [];
         foreach ($rows as $row) {
-            $values[$row['field_id']] = $row['value'];
+            $values[$row['field_id']] = [
+                'value' => $row['value'],
+                'checked' => (int) $row['checked'],
+            ];
         }
 
         return $values;

--- a/plugin/user_profile/ajax.php
+++ b/plugin/user_profile/ajax.php
@@ -1,0 +1,111 @@
+<?php
+require_once __DIR__.'/config.php';
+if (!api_get_configuration_value('plugin_user_profile_enabled')) {
+    api_not_allowed(true);
+}
+require_once __DIR__.'/UserProfilePlugin.php';
+require_once api_get_path(LIBRARY_PATH).'message.lib.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $check  = Security::check_token('post');
+    $status = 'error';
+
+    if ($check && isset($_POST['action'])) {
+        switch ($_POST['action']) {
+            case 'toggle':
+                $userId  = (int) ($_POST['user_id'] ?? 0);
+                $fieldId = (int) ($_POST['field_id'] ?? 0);
+                $checked = (int) ($_POST['checked'] ?? 0);
+
+                $tblValue = Database::get_main_table(UserProfilePlugin::TABLE_VALUE);
+                $where = ['user_id = ? AND field_id = ?' => [$userId, $fieldId]];
+                $exists = Database::select('id', $tblValue, ['where' => $where], 'first');
+
+                if ($exists) {
+                    Database::update($tblValue, ['checked' => $checked], $where);
+                } else {
+                    Database::insert($tblValue, [
+                        'user_id'  => $userId,
+                        'field_id' => $fieldId,
+                        'value'    => '',
+                        'checked'  => $checked,
+                    ]);
+                }
+                $status = 'ok';
+                break;
+
+            case 'warn':
+                $userId    = (int) ($_POST['user_id'] ?? 0);
+                $teacherId = (int) ($_POST['teacher_id'] ?? 0);
+                $tracking  = isset($_POST['tracking']) && (int) $_POST['tracking'] === 0 ? 0 : 1;
+
+                if ($userId && $teacherId) {
+                    $tblUser = Database::get_main_table(TABLE_MAIN_USER);
+                    $userInfo = Database::fetch_array(
+                        Database::query("SELECT firstname, lastname FROM $tblUser WHERE id = $userId"),
+                        'ASSOC'
+                    );
+                    $userName = $userInfo ? $userInfo['firstname'].' '.$userInfo['lastname'] : '';
+
+                    $tblField = Database::get_main_table(UserProfilePlugin::TABLE_FIELD);
+                    $tblValue = Database::get_main_table(UserProfilePlugin::TABLE_VALUE);
+                    $tblCat   = Database::get_main_table(UserProfilePlugin::TABLE_CATEGORY);
+                    $urlId    = api_get_current_access_url_id();
+
+                    $sql = "SELECT f.name, f.field_type, v.value
+                            FROM $tblField f
+                            LEFT JOIN $tblValue v ON (f.id = v.field_id AND v.user_id = $userId)
+                            LEFT JOIN $tblCat c ON (f.category_id = c.id)
+                            WHERE f.access_url_id = $urlId AND c.access_url_id = $urlId
+                              AND f.include_tracking = $tracking AND COALESCE(v.checked,0) = 0";
+                    $res = Database::query($sql);
+
+                    $lines = [];
+                    while ($row = Database::fetch_array($res, 'ASSOC')) {
+                        $value = $row['value'];
+                        if ($row['field_type'] === 'date' && !empty($value)) {
+                            $value = api_format_date($value, DATE_FORMAT_LONG);
+                        }
+                        $lines[] = '- '.$row['name'].' : '.$value;
+                    }
+
+                    $intro   = 'Bonjour, les éléments suivants méritent votre attention :';
+                    $outro   = 'Cordialement';
+                    $userUrl = api_get_path(WEB_CODE_PATH).'mySpace/myStudents.php?student='.$userId;
+                    $userLine = '<a href="'.$userUrl.'">'.$userName.'</a>';
+
+                    $body    = implode('<br>', $lines);
+                    $content = $intro.'<br><br>'.$userLine.'<br><br>'.$body.'<br><br>'.$outro;
+                    $subject = 'Avertissement pour '.$userName;
+
+                    $sent = MessageManager::send_message_simple($teacherId, $subject, $content, api_get_user_id());
+                    $status = $sent ? 'ok' : 'error';
+                }
+                break;
+
+            case 'remind_agenda':
+                $userId = (int) ($_POST['user_id'] ?? 0);
+                if ($userId) {
+                    $subject = 'Relance agenda';
+                    $content = "Bonjour, vous n'avez pas déclaré vos horaires de formation dans l'agenda. Merci de faire le nécessaire au plus vite. Cordialement";
+                    $sent = MessageManager::send_message_simple(
+                        $userId,
+                        $subject,
+                        $content,
+                        api_get_user_id()
+                    );
+                    $status = $sent ? 'ok' : 'error';
+                }
+                break;
+
+            default:
+                $status = 'error';
+        }
+    }
+
+    Security::clear_token();
+    header('Content-Type: application/json');
+    echo json_encode(['token' => Security::get_token(), 'status' => $status]);
+    exit;
+}
+?>

--- a/plugin/user_profile/pdf.php
+++ b/plugin/user_profile/pdf.php
@@ -6,6 +6,7 @@ if (!api_get_configuration_value('plugin_user_profile_enabled')) {
     api_not_allowed(true);
 }
 require_once __DIR__.'/UserProfilePlugin.php';
+require_once api_get_path(LIBRARY_PATH).'MyStudents.php';
 
 $userId = (int) ($_GET['id'] ?? api_get_user_id());
 $info = api_get_user_info($userId);
@@ -47,33 +48,25 @@ ob_start();
         <li class="list-group-item"><strong><?php echo get_lang('LastLogins'); ?>:</strong> <?php echo Security::remove_XSS($info['last_login']); ?></li>
     </ul>
 </div>
-<table width="100%">
-<?php $i = 0; foreach ($categories as $cat): ?>
-    <?php if ($i % 2 === 0): ?><tr><?php endif; ?>
-    <td width="50%" valign="top">
-        <div class="card user-profile mb-3">
-            <div class="card-title"><strong><?php echo Security::remove_XSS(UserProfilePlugin::getCategoryLabel($cat)); ?></strong></div>
-            <?php if (!empty($fieldsByCat[$cat['id']])): ?>
-            <ul class="list-group list-group-flush">
-                <?php foreach ($fieldsByCat[$cat['id']] as $field): ?>
-                <?php
-                $val = $field['value'];
-                if ($field['field_type'] === 'date' && !empty($val)) {
-                    $val = api_format_date($val, DATE_FORMAT_LONG);
-                }
-                ?>
-                <li class="list-group-item"><strong><?php echo Security::remove_XSS($field['name']); ?>:</strong> <?php echo Security::remove_XSS($val); ?></li>
-                <?php endforeach; ?>
-            </ul>
-            <?php endif; ?>
-        </div>
-    </td>
-    <?php if ($i % 2 === 1): ?></tr><?php endif; ?>
-<?php $i++; endforeach; ?>
-<?php if ($i % 2 === 1): ?><td width="50%"></td></tr><?php endif; ?>
-</table>
-        
+<?php foreach ($categories as $cat): ?>
+<div class="card user-profile mb-3">
+    <div class="card-title category-title"><strong><?php echo Security::remove_XSS(UserProfilePlugin::getCategoryLabel($cat)); ?></strong></div>
+    <?php if (!empty($fieldsByCat[$cat['id']])): ?>
+    <ul class="list-group list-group-flush">
+        <?php foreach ($fieldsByCat[$cat['id']] as $field): ?>
+        <?php
+        $val = $field['value'];
+        if ($field['field_type'] === 'date' && !empty($val)) {
+            $val = api_format_date($val, DATE_FORMAT_LONG);
+        }
+        ?>
+        <li class="list-group-item"><strong><?php echo Security::remove_XSS($field['name']); ?>:</strong> <?php echo Security::remove_XSS($val); ?></li>
+        <?php endforeach; ?>
+    </ul>
+    <?php endif; ?>
 </div>
+<?php endforeach; ?>
+<?php echo MyStudents::getBlockForSynthesis($userId, true); ?>
 <?php
 $html = ob_get_clean();
 

--- a/plugin/user_profile/tracking_untracked.php
+++ b/plugin/user_profile/tracking_untracked.php
@@ -6,10 +6,10 @@ if (!api_get_configuration_value('plugin_user_profile_enabled')) {
 require_once __DIR__.'/UserProfilePlugin.php';
 require_once api_get_path(LIBRARY_PATH).'sessionmanager.lib.php';
 require_once api_get_path(LIBRARY_PATH).'tracking.lib.php';
-require_once api_get_path(LIBRARY_PATH).'MyStudents.php';
 
 global $htmlHeadXtra;
-$token = Security::get_token();
+$ajaxUrl = api_get_path(WEB_PLUGIN_PATH).'user_profile/ajax.php';
+$token   = Security::get_token();
 $htmlHeadXtra[] = '<style>
     .user-profile.card {border:1px solid #eee;border-radius:4px;box-shadow:0 2px 4px rgba(0,0,0,0.05);margin-bottom:20px;}
     .user-profile .card-title {font-weight:bold;text-align:center;background:#f7f7f7;margin:0;padding:10px;}
@@ -24,54 +24,25 @@ $htmlHeadXtra[] = '<style>
 $htmlHeadXtra[] = '<script>
 var userProfileToken = "'.$token.'";
 $(function(){
-    $(document).on("click", ".agenda-remind-btn", function(e){
-        e.preventDefault();
-        var $card = $(this).closest(".user-profile");
-        var userId = $card.data("user-id");
-        $.post("'.api_get_path(WEB_PLUGIN_PATH).'user_profile/ajax.php", {
-            action: "remind_agenda",
-            user_id: userId,
-            sec_token: userProfileToken
-        }, function(resp){
-            if (resp && resp.token) {
-                userProfileToken = resp.token;
-            }
-            if (resp && resp.status === \'ok\') {
-                alert("Message envoyé");
-            } else {
-                alert("Erreur lors de l\'envoi du message");
-            }
-        }, "json");
-    });
-
-    $(document).on("click", ".warn-btn", function(e){
-        e.preventDefault();
-        var $card = $(this).closest(".user-profile");
-        var userId = $card.data("user-id");
-        var teacherId = $card.find(".teacher-select").val();
-        if(!teacherId){
-            alert("Veuillez sélectionner un formateur");
-            return;
-        }
-        $.post("'.api_get_path(WEB_PLUGIN_PATH).'user_profile/ajax.php", {
-            action: "warn",
-            user_id: userId,
-            teacher_id: teacherId,
-            sec_token: userProfileToken
-        }, function(resp){
-            if (resp && resp.token) {
-                userProfileToken = resp.token;
-            }
-            if (resp && resp.status === \'ok\') {
-                alert("Message envoyé");
-            } else {
-                alert("Erreur lors de l\'envoi du message");
-            }
-        }, "json");
-    });
-
     $(document).on("change", ".per-page-select", function(){
         $("#per-page-form").submit();
+    });
+    $(document).on("change", ".untracked-checkbox", function(){
+        var $cb = $(this);
+        var userId = $cb.closest(".card.user-profile").data("user-id");
+        var fieldId = $cb.data("field-id");
+        var checked = $cb.is(":checked") ? 1 : 0;
+        var $status = $cb.closest("td").find(".save-status");
+        $.post("'.$ajaxUrl.'", {action: "toggle", user_id: userId, field_id: fieldId, checked: checked, sec_token: userProfileToken}, function(resp){
+            if (resp) {
+                if (resp.token) {
+                    userProfileToken = resp.token;
+                }
+                if (resp.status === "ok") {
+                    $status.text("ok").show().delay(2000).fadeOut();
+                }
+            }
+        }, "json");
     });
 });
 </script>';
@@ -133,13 +104,10 @@ if ($perPage !== 'all') {
     $userSql .= " ORDER BY lastname, firstname";
 }
 $users = Database::query($userSql);
-// Preload teachers for selection list
-$teachersRes = Database::query("SELECT id, firstname, lastname FROM $tblUser WHERE status = ".COURSEMANAGER." ORDER BY lastname, firstname");
-$teachers = Database::store_result($teachersRes);
 
 Display::display_header(get_lang('UserTracking', 'user_profile'));
 
-// Navigation links to switch between pedagogical and administrative tracking
+// Navigation links between pedagogical and administrative tracking
 $current = basename($_SERVER['SCRIPT_NAME']);
 $links = [];
 if ($current === 'tracking.php') {
@@ -222,11 +190,8 @@ while ($user = Database::fetch_array($users)) {
         $lastLogin = Security::remove_XSS($lastLoginFormatted);
     }
 
-    [$thisWeekBox, $nextWeekBox] = MyStudents::getAgendaStatusBoxes($userId);
-
     echo '<li class="list-group-item"><strong>'.get_lang('RegistrationDate').':</strong> '.Security::remove_XSS($registrationDate).'</li>';
     echo '<li class="list-group-item"><strong>'.get_lang('LastLogins').':</strong> '.$lastLogin.'</li>';
-    echo '<li class="list-group-item"><strong>'.get_lang('Agenda').':</strong> '.$thisWeekBox.' | '.$nextWeekBox.' <button class="btn btn-warning ml-2 agenda-remind-btn">Relancer</button></li>';
     echo '</ul>';
 
     // Time spent last week
@@ -274,7 +239,7 @@ while ($user = Database::fetch_array($users)) {
 
     echo '</div>'; // row
 
-    // Tracked custom fields by category
+    // Untracked custom fields by category
     $tblField = Database::get_main_table(UserProfilePlugin::TABLE_FIELD);
     $tblValue = Database::get_main_table(UserProfilePlugin::TABLE_VALUE);
     $tblCat = Database::get_main_table(UserProfilePlugin::TABLE_CATEGORY);
@@ -282,7 +247,7 @@ while ($user = Database::fetch_array($users)) {
             FROM $tblField f
             LEFT JOIN $tblValue v ON (f.id = v.field_id AND v.user_id = $userId)
             LEFT JOIN $tblCat c ON (f.category_id = c.id)
-            WHERE f.access_url_id = $urlId AND c.access_url_id = $urlId AND f.include_tracking = 1
+            WHERE f.access_url_id = $urlId AND c.access_url_id = $urlId AND f.include_tracking = 0
             ORDER BY c.cat_order, f.field_order, f.id";
     $res = Database::query($sql);
     $fields = Database::store_result($res);
@@ -317,31 +282,16 @@ while ($user = Database::fetch_array($users)) {
                     echo ' : '.$val;
                 }
                 echo '</td>';
-                echo '<td class="text-right"><input type="checkbox" disabled'.$checkedAttr.'></td>';
+                echo '<td class="text-right"><input type="checkbox" class="untracked-checkbox" data-field-id="'.$field['id'].'"'.$checkedAttr.'> <span class="save-status text-success" style="display:none;"></span></td>';
                 echo '</tr>';
             }
             echo '</tbody></table></div>';
             echo '</div>';
         }
     }
-    // Selection list of teachers
-    if (!empty($teachers)) {
-        echo '<div class="mt-3">';
-        echo '<label>'.get_lang('Teacher').'</label>';
-        echo '<select class="form-control teacher-select">';
-        // Default empty option so no teacher is pre-selected
-        echo '<option value=""></option>';
-        foreach ($teachers as $teacher) {
-            $fullName = $teacher['firstname'].' '.$teacher['lastname'];
-            echo '<option value="'.((int) $teacher['id']).'">'.Security::remove_XSS($fullName).'</option>';
-        }
-        echo '</select>';
-        echo '</div>';
-    }
     echo '<div class="text-center mt-3">';
     echo '<a class="btn btn-danger" title="Accéder au suivi" href="'.Security::remove_XSS($detailsUrl).'">Suivi</a>';
     echo '<a class="btn btn-primary ml-2" href="'.Security::remove_XSS($profileUrl).'">'.get_lang('UserProfile').'</a>';
-    echo '<button class="btn btn-success ml-2 warn-btn" title="Alerter l\'enseignant des échéances en retard">Avertir</button>';
     echo '</div>';
     echo '</div>'; // card-body
     echo '</div></div>';

--- a/plugin/user_profile/view.php
+++ b/plugin/user_profile/view.php
@@ -1,12 +1,15 @@
 <?php
 require_once __DIR__.'/config.php';
 require_once __DIR__.'/UserProfilePlugin.php';
+require_once api_get_path(LIBRARY_PATH).'MyStudents.php';
 
 if (!api_get_configuration_value('plugin_user_profile_enabled')) {
     api_not_allowed(true);
 }
 
 global $htmlHeadXtra;
+$htmlHeadXtra[] = '<script src="'.api_get_path(WEB_PUBLIC_PATH)
+    .'assets/jquery.easy-pie-chart/dist/jquery.easypiechart.js"></script>';
 $htmlHeadXtra[] = '<style>
     .user-profile.card {
         border: 1px solid #eee;
@@ -18,9 +21,12 @@ $htmlHeadXtra[] = '<style>
     .user-profile .card-title {
         font-weight: bold;
         text-align: center;
-        background: #f7f7f7;
+        background: #E1F0F5;
         margin: 0;
         padding: 10px;
+    }
+    .user-profile .card-title.category-title {
+        background: #E1F0F5;
     }
     .list-group-item {
     border: 0px solid #ddd;
@@ -51,20 +57,18 @@ $fieldsByCat = [];
 Display::display_header(get_lang('UserProfile'));
 
 $pdfUrl = api_get_path(WEB_PLUGIN_PATH).'user_profile/pdf.php?id='.$userId;
-$pdfLink = Display::url(
-    Display::return_icon('icons\32\export_pdf.png', get_lang('ExportToPdf')),
-    $pdfUrl
-);
-$backLink = '';
-if (!empty($_GET['from_search'])) {
-    $backLink = Display::url(
-        Display::return_icon('back.png', get_lang('Back')),
-        UserProfilePlugin::create()->getAdminUrl(),
-        ['class' => 'mr-2']
-    );
-}
-echo '<div class="d-flex justify-content-between align-items-center">';
-echo '<div>'.$backLink.$pdfLink.'</div>';
+$xlsUrl = api_get_path(WEB_PLUGIN_PATH).'user_profile/xls.php?id='.$userId;
+$pdfLink = '<a href="'.$pdfUrl.'" class="mr-2">'
+    .Display::return_icon('icons\\32\\export_pdf.png', get_lang('ExportToPdf')).'</a>';
+$xlsLink = '<a href="'.$xlsUrl.'">'
+    .Display::return_icon('icons\\32\\export_excel.png', get_lang('ExportAsXLS')).'</a>';
+$backLink = '<a href="javascript:history.back();" class="mr-2">'
+    .Display::return_icon('back.png', get_lang('Back')).'</a>';
+$editUrl = api_get_path(WEB_CODE_PATH).'admin/user_edit.php?user_id='.$userId;
+$editLink = '<a href="'.$editUrl.'" class="mr-2">'
+    .Display::return_icon('icons\\32\\edit.png', get_lang('Edit')).'</a>';
+echo '<div class="mb-2">';
+echo $backLink.$editLink.$pdfLink.$xlsLink;
 echo '</div>';
 
 // Built-in fields
@@ -89,13 +93,11 @@ foreach ($fields as $field) {
     $fieldsByCat[$field['category_id']][] = $field;
 }
 $categories = UserProfilePlugin::create()->getCategories();
-echo '<div class="row">';
 foreach ($categories as $cat) {
     $catId = $cat['id'];
     $label = UserProfilePlugin::getCategoryLabel($cat);
-    echo '<div class="col-md-6">';
     echo '<div class="card user-profile mb-3">';
-    echo '<div class="card-title"><strong>'.$label.'</strong></div>';
+    echo '<div class="card-title category-title"><strong>'.$label.'</strong></div>';
     if (!empty($fieldsByCat[$catId])) {
         echo '<ul class="list-group list-group-flush">';
         foreach ($fieldsByCat[$catId] as $field) {
@@ -107,9 +109,10 @@ foreach ($categories as $cat) {
         }
         echo '</ul>';
     }
-    echo '</div></div>';
+    echo '</div>';
 }
-echo '</div>';
+
+echo MyStudents::getBlockForSynthesis($userId);
 
 Display::display_footer();
 ?>

--- a/plugin/user_profile/xls.php
+++ b/plugin/user_profile/xls.php
@@ -1,0 +1,168 @@
+<?php
+require_once __DIR__.'/config.php';
+if (!api_get_configuration_value('plugin_user_profile_enabled')) {
+    api_not_allowed(true);
+}
+require_once __DIR__.'/UserProfilePlugin.php';
+require_once api_get_path(LIBRARY_PATH).'MyStudents.php';
+
+$userId = (int) ($_GET['id'] ?? api_get_user_id());
+$info = api_get_user_info($userId);
+if (empty($info)) {
+    api_not_allowed(true);
+}
+
+// Gather plugin fields by category.
+$plugin = UserProfilePlugin::create();
+$urlId = api_get_current_access_url_id();
+$tblField = Database::get_main_table(UserProfilePlugin::TABLE_FIELD);
+$tblValue = Database::get_main_table(UserProfilePlugin::TABLE_VALUE);
+$tblCat   = Database::get_main_table(UserProfilePlugin::TABLE_CATEGORY);
+$sql = "SELECT f.id, f.name, f.field_type, f.category_id, v.value
+        FROM $tblField f
+        LEFT JOIN $tblValue v ON (f.id = v.field_id AND v.user_id = $userId)
+        LEFT JOIN $tblCat c ON (f.category_id = c.id)
+        WHERE f.access_url_id = $urlId AND c.access_url_id = $urlId
+        ORDER BY f.field_order, f.id";
+$result = Database::query($sql);
+$fields = Database::store_result($result);
+$fieldsByCat = [];
+foreach ($fields as $field) {
+    $fieldsByCat[$field['category_id']][] = $field;
+}
+$categories = $plugin->getCategories();
+
+// Build a simple HTML table for Excel without style tags.
+$html  = '<table border="1">';
+$html .= '<tr><th colspan="2">'.get_lang('PlatformFields', 'user_profile').'</th></tr>';
+$html .= '<tr><td>'.get_lang('FirstName').'</td><td>'.Security::remove_XSS($info['firstname']).'</td></tr>';
+$html .= '<tr><td>'.get_lang('LastName').'</td><td>'.Security::remove_XSS($info['lastname']).'</td></tr>';
+$html .= '<tr><td>'.get_lang('Email').'</td><td>'.Security::remove_XSS($info['email']).'</td></tr>';
+$html .= '<tr><td>'.get_lang('OfficialCode').'</td><td>'.Security::remove_XSS($info['official_code']).'</td></tr>';
+$html .= '<tr><td>'.get_lang('Phone').'</td><td>'.Security::remove_XSS($info['phone']).'</td></tr>';
+$html .= '<tr><td>'.get_lang('RegistrationDate').'</td><td>'.Security::remove_XSS($info['registration_date']).'</td></tr>';
+$html .= '<tr><td>'.get_lang('LastLogins').'</td><td>'.Security::remove_XSS($info['last_login']).'</td></tr>';
+
+foreach ($categories as $cat) {
+    $html .= '<tr><th colspan="2">'.Security::remove_XSS(UserProfilePlugin::getCategoryLabel($cat)).'</th></tr>';
+    if (!empty($fieldsByCat[$cat['id']])) {
+        foreach ($fieldsByCat[$cat['id']] as $field) {
+            $val = $field['value'];
+            if ($field['field_type'] === 'date' && !empty($val)) {
+                $val = api_format_date($val, DATE_FORMAT_LONG);
+            }
+            $html .= '<tr><td>'.Security::remove_XSS($field['name']).'</td><td>'.Security::remove_XSS($val).'</td></tr>';
+        }
+    }
+}
+
+// Synthesis section.
+$orderCondition = null;
+if (api_get_configuration_value('session_list_order')) {
+    $orderCondition = ' ORDER BY s.position ASC';
+}
+$sessions = SessionManager::getSessionsFollowedByUser(
+    $userId,
+    null,
+    null,
+    null,
+    false,
+    false,
+    false,
+    $orderCondition
+);
+$sessionProgressList = [];
+$totalSessionsProgress = 0;
+foreach ($sessions as $sessionItem) {
+    $courses = SessionManager::get_course_list_by_session_id($sessionItem['id']);
+    $courseProgressSum = 0;
+    $courseCount = 0;
+    foreach ($courses as $courseItem) {
+        $courseInfoItem = api_get_course_info_by_id($courseItem['real_id']);
+        $courseCodeItem = $courseInfoItem['code'];
+        if (CourseManager::is_user_subscribed_in_course($userId, $courseCodeItem, true, $sessionItem['id'])) {
+            $progressValue = Tracking::get_avg_student_progress(
+                $userId,
+                $courseCodeItem,
+                [],
+                $sessionItem['id']
+            );
+            if (is_numeric($progressValue)) {
+                $courseProgressSum += $progressValue;
+            }
+            $courseCount++;
+        }
+    }
+    $progress = $courseCount > 0 ? round($courseProgressSum / $courseCount, 2) : 0;
+    $sessionProgressList[] = [
+        'name' => $sessionItem['name'],
+        'progress' => $progress,
+    ];
+    $totalSessionsProgress += $progress;
+}
+$avgSessionsProgress = !empty($sessionProgressList) ? round($totalSessionsProgress / count($sessionProgressList), 2) : 0;
+
+$aLastWeek = get_last_week();
+$startWeek = date('Y-m-d', $aLastWeek[0]);
+$endWeek = date('Y-m-d', $aLastWeek[6]);
+$report = Tracking::generateReport('time_report', [$userId], $startWeek, $endWeek);
+$timeSeconds = 0;
+foreach ($report['rows'] as $reportRow) {
+    $timeParts = explode(':', $reportRow[6]);
+    if (count($timeParts) === 3) {
+        [$hours, $minutes, $seconds] = array_map('intval', $timeParts);
+        $timeSeconds += ($hours * 3600) + ($minutes * 60) + $seconds;
+    }
+}
+$timeSpentLastWeek = api_time_to_hms($timeSeconds);
+
+$weeksToShow = 52;
+$currentMonday = strtotime('monday this week');
+$weekData = [];
+for ($i = 1; $i <= $weeksToShow; $i++) {
+    $weekStart = strtotime('-'.$i.' week', $currentMonday);
+    $weekEnd = $weekStart + (6 * 86400);
+    $startDate = date('Y-m-d', $weekStart);
+    $endDate = date('Y-m-d', $weekEnd);
+    $reportWeek = Tracking::generateReport('time_report', [$userId], $startDate, $endDate);
+    $weekSeconds = 0;
+    foreach ($reportWeek['rows'] as $reportRow) {
+        $parts = explode(':', $reportRow[6]);
+        if (count($parts) === 3) {
+            [$h, $m, $s] = array_map('intval', $parts);
+            $weekSeconds += ($h * 3600) + ($m * 60) + $s;
+        }
+    }
+    $label = date('Y', $weekStart).' - '.date('W', $weekStart);
+    $weekData[] = [
+        'label' => $label,
+        'time'  => api_time_to_hms($weekSeconds),
+    ];
+}
+
+$html .= '<tr><th colspan="2">'.get_lang('synthesis').'</th></tr>';
+$html .= '<tr><td>'.get_lang('TimeSpentInCoursesLastWeek').'</td><td>'.$timeSpentLastWeek.'</td></tr>';
+$html .= '<tr><td>'.get_lang('AverageProgressInSessions').'</td><td>'.$avgSessionsProgress.'%</td></tr>';
+if (!empty($sessionProgressList)) {
+    $html .= '<tr><th colspan="2">'.get_lang('ProgressionInSessions').'</th></tr>';
+    foreach ($sessionProgressList as $item) {
+        $html .= '<tr><td>'.Security::remove_XSS($item['name']).'</td><td>'.$item['progress'].'%</td></tr>';
+    }
+}
+if (!empty($weekData)) {
+    $html .= '<tr><th colspan="2">'.get_lang('WeeklyTimeSummary').'</th></tr>';
+    $html .= '<tr><th>'.get_lang('Week').'</th><th>'.get_lang('LatencyTimeSpent').'</th></tr>';
+    foreach ($weekData as $week) {
+        $html .= '<tr><td>'.Security::remove_XSS($week['label']).'</td><td>'.$week['time'].'</td></tr>';
+    }
+}
+$html .= '</table>';
+
+header('Content-Type: application/vnd.ms-excel; charset=UTF-8');
+header('Content-Disposition: attachment; filename="user_profile_'.$info['username'].'.xls"');
+header('Pragma: no-cache');
+header('Expires: 0');
+
+echo "\xEF\xBB\xBF";
+echo $html;
+


### PR DESCRIPTION
## Summary
- Restore agenda status line and reminder on main tracking page
- Drop agenda display from untracked tracking view
- Allow untracked tracking checkboxes to update via AJAX without page reload
- Add navigation links between pedagogical and administrative tracking pages

## Testing
- `php -l plugin/user_profile/tracking.php`
- `php -l plugin/user_profile/tracking_untracked.php`
- `php -l plugin/user_profile/ajax.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894e9c65e00832ba99dba9b7dd7d9be