### PR TITLE
feat: support teacher assignments in user profile

### DIFF
--- a/main/admin/user_add.php
+++ b/main/admin/user_add.php
@@ -332,6 +332,10 @@ $profilePluginEnabled = api_get_configuration_value('plugin_user_profile_enabled
 $pluginInstalled = AppPlugin::getInstance()->isInstalled('user_profile');
 if ($profilePluginEnabled && $pluginInstalled) {
     $profilePlugin->addFieldsToForm($form);
+    $teacherOptions = $profilePlugin->getTeacherOptions();
+    if (!empty($teacherOptions)) {
+        $form->addSelect('teachers', get_lang('Teachers'), $teacherOptions, ['multiple' => 'multiple']);
+    }
 }
 
 $allowEmailTemplate = api_get_configuration_value('mail_template_system');
@@ -498,6 +502,7 @@ if ($form->validate()) {
             $extraFieldValues->saveFieldValues($user);
             if ($profilePluginEnabled && $pluginInstalled) {
                 $profilePlugin->saveUserValues($user_id, $user);
+                $profilePlugin->saveUserTeachers($user_id, $user['teachers'] ?? []);
             }
             $message = get_lang('UserAdded').': '.
                 Display::url(

--- a/main/admin/user_edit.php
+++ b/main/admin/user_edit.php
@@ -394,6 +394,10 @@ $returnParams = $extraField->addElements(
 );
 if ($profilePluginEnabled && $pluginInstalled) {
     $profilePlugin->addFieldsToForm($form, $user_data['user_id']);
+    $teacherOptions = $profilePlugin->getTeacherOptions();
+    if (!empty($teacherOptions)) {
+        $form->addSelect('teachers', get_lang('Teachers'), $teacherOptions, ['multiple' => 'multiple']);
+    }
 }
 $jqueryReadyContent = $returnParams['jquery_ready_content'];
 
@@ -439,6 +443,12 @@ if (empty($expiration_date)) {
     $user_data['expiration_date'] = api_get_local_time($expiration_date);
 }
 $form->setDefaults($user_data);
+if ($profilePluginEnabled && $pluginInstalled) {
+    $selectedTeachers = $profilePlugin->getUserTeachers($user_id);
+    if (!empty($selectedTeachers)) {
+        $form->setDefaults(['teachers' => $selectedTeachers]);
+    }
+}
 
 $error_drh = false;
 // Validate form
@@ -571,6 +581,7 @@ if ($form->validate()) {
     $extraFieldValue->saveFieldValues($user);
     if ($profilePluginEnabled && $pluginInstalled) {
         $profilePlugin->saveUserValues($user_id, $user);
+        $profilePlugin->saveUserTeachers($user_id, $user['teachers'] ?? []);
     }
     $userInfo = api_get_user_info($user_id);
     $message = get_lang('UserUpdated').': '.Display::url(

--- a/plugin/user_profile/UserProfilePlugin.php
+++ b/plugin/user_profile/UserProfilePlugin.php
@@ -7,6 +7,7 @@ class UserProfilePlugin extends Plugin implements HookPluginInterface
     public const TABLE_FIELD = 'plugin_user_profile_field';
     public const TABLE_VALUE = 'plugin_user_profile_value';
     public const TABLE_CATEGORY = 'plugin_user_profile_category';
+    public const TABLE_TEACHERS = 'plugin_user_profile_teachers';
 
     public function get_name(): string
     {
@@ -43,6 +44,7 @@ class UserProfilePlugin extends Plugin implements HookPluginInterface
         $tblField = Database::get_main_table(self::TABLE_FIELD);
         $tblValue = Database::get_main_table(self::TABLE_VALUE);
         $tblCat = Database::get_main_table(self::TABLE_CATEGORY);
+        $tblTeachers = Database::get_main_table(self::TABLE_TEACHERS);
         $urlId = api_get_current_access_url_id();
 
         $sql = "CREATE TABLE IF NOT EXISTS $tblCat (
@@ -87,12 +89,18 @@ class UserProfilePlugin extends Plugin implements HookPluginInterface
             Database::query("ALTER TABLE $tblValue ADD checked TINYINT(1) NOT NULL DEFAULT 0");
         }
 
+        $sql = "CREATE TABLE IF NOT EXISTS $tblTeachers (
+            user_id INT NOT NULL PRIMARY KEY,
+            teacher_ids TEXT
+        )";
+        Database::query($sql);
+
         $this->installHook();
     }
 
     public function uninstall()
     {
-        $tables = [self::TABLE_FIELD, self::TABLE_VALUE, self::TABLE_CATEGORY];
+        $tables = [self::TABLE_FIELD, self::TABLE_VALUE, self::TABLE_CATEGORY, self::TABLE_TEACHERS];
         foreach ($tables as $table) {
             $tableName = Database::get_main_table($table);
             $sql = "DROP TABLE IF EXISTS $tableName";
@@ -139,6 +147,11 @@ class UserProfilePlugin extends Plugin implements HookPluginInterface
     public function getTrackingUrl(): string
     {
         return api_get_path(WEB_PLUGIN_PATH).$this->get_name().'/tracking.php';
+    }
+
+    public function getTeacherManagementUrl(): string
+    {
+        return api_get_path(WEB_PLUGIN_PATH).$this->get_name().'/teachers.php';
     }
 
     public function getCategories(): array
@@ -239,6 +252,57 @@ class UserProfilePlugin extends Plugin implements HookPluginInterface
         }
 
         return $values;
+    }
+
+    public function getTeacherOptions(): array
+    {
+        $tblUser = Database::get_main_table(TABLE_MAIN_USER);
+        $res = Database::query("SELECT id, firstname, lastname FROM $tblUser WHERE status = ".COURSEMANAGER." ORDER BY lastname, firstname");
+        $options = [];
+        while ($row = Database::fetch_array($res)) {
+            $options[$row['id']] = $row['firstname'].' '.$row['lastname'];
+        }
+        return $options;
+    }
+
+    public function saveUserTeachers(int $userId, array $teacherIds): void
+    {
+        $table = Database::get_main_table(self::TABLE_TEACHERS);
+        $teacherIds = array_unique(array_filter(array_map('intval', $teacherIds)));
+        $data = ['teacher_ids' => implode(',', $teacherIds)];
+        $exists = Database::select('user_id', $table, ['where' => ['user_id = ?' => $userId]], 'first');
+        if ($exists) {
+            Database::update($table, $data, ['user_id = ?' => $userId]);
+        } else {
+            $data['user_id'] = $userId;
+            Database::insert($table, $data);
+        }
+    }
+
+    public function getUserTeachers(int $userId): array
+    {
+        $table = Database::get_main_table(self::TABLE_TEACHERS);
+        $row = Database::select('teacher_ids', $table, ['where' => ['user_id = ?' => $userId]], 'first');
+        if (!$row || empty($row['teacher_ids'])) {
+            return [];
+        }
+        return array_filter(array_map('intval', explode(',', $row['teacher_ids'])));
+    }
+
+    public function getTeacherNamesForUser(int $userId): string
+    {
+        $ids = $this->getUserTeachers($userId);
+        if (empty($ids)) {
+            return '';
+        }
+        $tblUser = Database::get_main_table(TABLE_MAIN_USER);
+        $idList = implode(',', array_map('intval', $ids));
+        $res = Database::query("SELECT firstname, lastname FROM $tblUser WHERE id IN ($idList) ORDER BY lastname, firstname");
+        $names = [];
+        while ($row = Database::fetch_array($res)) {
+            $names[] = $row['firstname'].' '.$row['lastname'];
+        }
+        return implode(', ', $names);
     }
 }
 ?>

--- a/plugin/user_profile/ajax.php
+++ b/plugin/user_profile/ajax.php
@@ -35,11 +35,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 break;
 
             case 'warn':
-                $userId    = (int) ($_POST['user_id'] ?? 0);
-                $teacherId = (int) ($_POST['teacher_id'] ?? 0);
-                $tracking  = isset($_POST['tracking']) && (int) $_POST['tracking'] === 0 ? 0 : 1;
+                $userId   = (int) ($_POST['user_id'] ?? 0);
+                $tracking = isset($_POST['tracking']) && (int) $_POST['tracking'] === 0 ? 0 : 1;
 
-                if ($userId && $teacherId) {
+                if ($userId) {
+                    $plugin = UserProfilePlugin::create();
+                    $teacherIds = $plugin->getUserTeachers($userId);
+                    if (empty($teacherIds)) {
+                        $status = 'no_teacher';
+                        break;
+                    }
+
                     $tblUser = Database::get_main_table(TABLE_MAIN_USER);
                     $userInfo = Database::fetch_array(
                         Database::query("SELECT firstname, lastname FROM $tblUser WHERE id = $userId"),
@@ -61,9 +67,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $res = Database::query($sql);
 
                     $lines = [];
+                    $now = time();
                     while ($row = Database::fetch_array($res, 'ASSOC')) {
                         $value = $row['value'];
-                        if ($row['field_type'] === 'date' && !empty($value)) {
+                        if ($row['field_type'] === 'date') {
+                            if (empty($value) || strtotime($value) >= $now) {
+                                continue;
+                            }
                             $value = api_format_date($value, DATE_FORMAT_LONG);
                         }
                         $lines[] = '- '.$row['name'].' : '.$value;
@@ -78,8 +88,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $content = $intro.'<br><br>'.$userLine.'<br><br>'.$body.'<br><br>'.$outro;
                     $subject = 'Avertissement pour '.$userName;
 
-                    $sent = MessageManager::send_message_simple($teacherId, $subject, $content, api_get_user_id());
-                    $status = $sent ? 'ok' : 'error';
+                    $allSent = true;
+                    foreach ($teacherIds as $teacherId) {
+                        $sent = MessageManager::send_message_simple($teacherId, $subject, $content, api_get_user_id());
+                        $allSent = $allSent && $sent;
+                    }
+                    $status = $allSent ? 'ok' : 'error';
                 }
                 break;
 
@@ -95,6 +109,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         api_get_user_id()
                     );
                     $status = $sent ? 'ok' : 'error';
+                }
+                break;
+
+            case 'save_teachers':
+                $userId = (int) ($_POST['user_id'] ?? 0);
+                $teacherIds = $_POST['teachers'] ?? [];
+                if ($userId) {
+                    $plugin = UserProfilePlugin::create();
+                    $plugin->saveUserTeachers($userId, is_array($teacherIds) ? $teacherIds : []);
+                    $status = 'ok';
                 }
                 break;
 

--- a/plugin/user_profile/lang/english.php
+++ b/plugin/user_profile/lang/english.php
@@ -15,4 +15,9 @@ $strings['CurrentCategories'] = 'Current categories';
 $strings['PlatformFields'] = 'USER';
 $strings['SearchUser'] = 'Search user (name or surname)';
 $strings['SearchResults'] = 'Search results';
+$strings['TeacherManagement'] = 'Teacher management';
+$strings['TeacherAssignment'] = 'Teacher assignment';
+$strings['NoTeacher'] = 'No teacher';
+$strings['UpdateSuccess'] = 'Update successful';
+$strings['UpdateError'] = 'Update failed';
 ?>

--- a/plugin/user_profile/lang/french.php
+++ b/plugin/user_profile/lang/french.php
@@ -23,4 +23,9 @@ $strings['CurrentCategories'] = 'Catégories actuelles';
 $strings['PlatformFields'] = 'UTILISATEUR';
 $strings['SearchUser'] = 'Rechercher';
 $strings['SearchResults'] = 'Résultat de la recherche';
+$strings['TeacherManagement'] = 'Gestion des enseignants';
+$strings['TeacherAssignment'] = 'Affectation des enseignants';
+$strings['NoTeacher'] = 'Pas d\'enseignant';
+$strings['UpdateSuccess'] = 'Mise à jour réussie';
+$strings['UpdateError'] = 'Échec de la mise à jour';
 ?>

--- a/plugin/user_profile/pdf.php
+++ b/plugin/user_profile/pdf.php
@@ -32,27 +32,50 @@ foreach ($fields as $field) {
     $fieldsByCat[$field['category_id']][] = $field;
 }
 $categories = $plugin->getCategories();
+$teacherNames = $plugin->getTeacherNamesForUser($userId);
+$teacherDisplay = $teacherNames !== '' ? $teacherNames : '-';
 
 ob_start();
 ?>
-<h2><?php echo get_lang('UserProfile'); ?></h2>
-<div class="card user-profile mb-3">
-    <div class="card-title"><strong><?php echo get_lang('PlatformFields', 'user_profile'); ?></strong></div>
-    <ul class="list-group list-group-flush">
-        <li class="list-group-item"><strong><?php echo get_lang('FirstName'); ?>:</strong> <?php echo Security::remove_XSS($info['firstname']); ?></li>
-        <li class="list-group-item"><strong><?php echo get_lang('LastName'); ?>:</strong> <?php echo Security::remove_XSS($info['lastname']); ?></li>
-        <li class="list-group-item"><strong><?php echo get_lang('Email'); ?>:</strong> <?php echo Security::remove_XSS($info['email']); ?></li>
-        <li class="list-group-item"><strong><?php echo get_lang('OfficialCode'); ?>:</strong> <?php echo Security::remove_XSS($info['official_code']); ?></li>
-        <li class="list-group-item"><strong><?php echo get_lang('Phone'); ?>:</strong> <?php echo Security::remove_XSS($info['phone']); ?></li>
-        <li class="list-group-item"><strong><?php echo get_lang('RegistrationDate'); ?>:</strong> <?php echo Security::remove_XSS($info['registration_date']); ?></li>
-        <li class="list-group-item"><strong><?php echo get_lang('LastLogins'); ?>:</strong> <?php echo Security::remove_XSS($info['last_login']); ?></li>
-    </ul>
+<h2 style="text-align:center;font-weight:bold;">FICHE UTILISATEUR</h2>
+<div style="border:1px solid #ccd9e6;margin-bottom:15px;">
+    <div style="background-color:#e6f2ff;text-align:center;font-weight:bold;padding:4px;">
+        <strong><?php echo get_lang('PlatformFields', 'user_profile'); ?></strong>
+    </div>
+    <table width="100%" cellpadding="4" cellspacing="0" style="border-collapse:collapse;">
+        <tr>
+            <td><strong><?php echo get_lang('FirstName'); ?>:</strong> <?php echo Security::remove_XSS($info['firstname']); ?></td>
+        </tr>
+        <tr>
+            <td><strong><?php echo get_lang('LastName'); ?>:</strong> <?php echo Security::remove_XSS($info['lastname']); ?></td>
+        </tr>
+        <tr>
+            <td><strong><?php echo get_lang('Email'); ?>:</strong> <?php echo Security::remove_XSS($info['email']); ?></td>
+        </tr>
+        <tr>
+            <td><strong><?php echo get_lang('OfficialCode'); ?>:</strong> <?php echo Security::remove_XSS($info['official_code']); ?></td>
+        </tr>
+        <tr>
+            <td><strong><?php echo get_lang('Phone'); ?>:</strong> <?php echo Security::remove_XSS($info['phone']); ?></td>
+        </tr>
+        <tr>
+            <td><strong><?php echo get_lang('RegistrationDate'); ?>:</strong> <?php echo Security::remove_XSS($info['registration_date']); ?></td>
+        </tr>
+        <tr>
+            <td><strong><?php echo get_lang('LastLogins'); ?>:</strong> <?php echo Security::remove_XSS($info['last_login']); ?></td>
+        </tr>
+        <tr>
+            <td><strong><?php echo get_lang('Teachers'); ?>:</strong> <?php echo Security::remove_XSS($teacherDisplay); ?></td>
+        </tr>
+    </table>
 </div>
 <?php foreach ($categories as $cat): ?>
-<div class="card user-profile mb-3">
-    <div class="card-title category-title"><strong><?php echo Security::remove_XSS(UserProfilePlugin::getCategoryLabel($cat)); ?></strong></div>
+<div style="border:1px solid #ccd9e6;margin-bottom:15px;">
+    <div style="background-color:#e6f2ff;text-align:center;font-weight:bold;padding:4px;">
+        <strong><?php echo Security::remove_XSS(UserProfilePlugin::getCategoryLabel($cat)); ?></strong>
+    </div>
     <?php if (!empty($fieldsByCat[$cat['id']])): ?>
-    <ul class="list-group list-group-flush">
+    <table width="100%" cellpadding="4" cellspacing="0" style="border-collapse:collapse;">
         <?php foreach ($fieldsByCat[$cat['id']] as $field): ?>
         <?php
         $val = $field['value'];
@@ -60,9 +83,11 @@ ob_start();
             $val = api_format_date($val, DATE_FORMAT_LONG);
         }
         ?>
-        <li class="list-group-item"><strong><?php echo Security::remove_XSS($field['name']); ?>:</strong> <?php echo Security::remove_XSS($val); ?></li>
+        <tr>
+            <td><strong><?php echo Security::remove_XSS($field['name']); ?>:</strong> <?php echo Security::remove_XSS($val); ?></td>
+        </tr>
         <?php endforeach; ?>
-    </ul>
+     </table>
     <?php endif; ?>
 </div>
 <?php endforeach; ?>
@@ -75,7 +100,9 @@ $header = '<div style="text-align:right;"><img src="'.$logo.'" height="50"></div
 $date = api_format_date(api_get_local_time(), DATE_TIME_FORMAT_LONG);
 $footer = '<table width="100%"><tr><td>'.$date.'</td><td style="text-align:right">{PAGENO}/{nb}</td></tr></table>';
 
-$pdf = new PDF();
-$pdf->set_custom_header($header);
-$pdf->set_custom_footer($footer);
-$pdf->content_to_pdf($html, '', 'user_profile_'.$info['username']);
+$tpl = new Template('', false, false, false, false, true, false);
+$tpl->assign('pdf_header', $header);
+$tpl->assign('pdf_footer', $footer);
+$pdf = new PDF('A4', 'P', [], $tpl);
+$pdf->params['filename'] = 'user_profile_'.$info['username'];
+$pdf->html_to_pdf_with_template($html, false, false, true);

--- a/plugin/user_profile/src/HookUserProfile.php
+++ b/plugin/user_profile/src/HookUserProfile.php
@@ -53,6 +53,10 @@ class HookUserProfile extends HookObserver implements HookCreateUserObserverInte
                 'url' => UserProfilePlugin::create()->getTrackingUrl(),
                 'label' => get_plugin_lang('UserTracking', 'user_profile'),
             ];
+            $data['blocks']['user']['items'][] = [
+                'url' => UserProfilePlugin::create()->getTeacherManagementUrl(),
+                'label' => get_lang('TeacherManagement', 'user_profile'),
+            ];
             return $data;
         }
 

--- a/plugin/user_profile/teachers.php
+++ b/plugin/user_profile/teachers.php
@@ -1,0 +1,209 @@
+<?php
+require_once __DIR__.'/config.php';
+require_once __DIR__.'/UserProfilePlugin.php';
+
+$enabled = api_get_configuration_value('plugin_user_profile_enabled');
+if (!$enabled) {
+    api_not_allowed(true);
+}
+
+api_protect_admin_script();
+$plugin = UserProfilePlugin::create();
+
+$token = Security::get_token();
+global $htmlHeadXtra;
+
+// Messages sans addslashes (on passera par json_encode ensuite)
+$successMsg = get_lang('UpdateSuccess', 'user_profile');
+$errorMsg   = get_lang('UpdateError', 'user_profile');
+$ajaxUrl    = api_get_path(WEB_PLUGIN_PATH).'user_profile/ajax.php';
+
+// Préparer les valeurs encodées en JSON pour éviter toute interpolation hasardeuse
+$jsonFlags  = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP;
+$tokenJs    = json_encode($token, $jsonFlags);
+$successJs  = json_encode($successMsg, $jsonFlags);
+$errorJs    = json_encode($errorMsg, $jsonFlags);
+$ajaxUrlJs  = json_encode($ajaxUrl, $jsonFlags);
+
+// Injecter le style et le script via $htmlHeadXtra
+$htmlHeadXtra[] = <<<JS
+<style>
+.teacher-item{display:flex;align-items:center;cursor:pointer;}
+.teacher-name{flex-grow:1;}
+.teacher-check{display:none;margin-left:8px;}
+.teacher-item.checked .teacher-check{display:inline;}
+.teacher-msg{margin-left:8px;}
+</style>
+<script>
+let userProfileTeacherToken = {$tokenJs};
+const teacherSuccessMsg = {$successJs};
+const teacherErrorMsg = {$errorJs};
+const ajaxUrl = {$ajaxUrlJs};
+
+$(function(){
+    $(document).on("click", ".teacher-item", function(){
+        const item = $(this);
+        const list = item.closest('.teacher-list');
+        const userId = list.data('user-id');
+        item.toggleClass('checked');
+        const teachers = list.find('.teacher-item.checked').map(function(){
+            return $(this).data('teacher-id');
+        }).get();
+        $.post(ajaxUrl, {
+            action: 'save_teachers',
+            user_id: userId,
+            teachers: teachers,
+            sec_token: userProfileTeacherToken
+        }, function(resp){
+            if (resp && resp.token) {
+                userProfileTeacherToken = resp.token;
+            }
+            const ok = resp && resp.status === 'ok';
+            const msg = ok ? teacherSuccessMsg : teacherErrorMsg;
+            item.find('.teacher-msg')
+                .text(msg)
+                .removeClass('text-success text-danger')
+                .addClass(ok ? 'text-success' : 'text-danger');
+            if (!ok) {
+                item.toggleClass('checked');
+            }
+            setTimeout(function(){ item.find('.teacher-msg').text(''); }, 3000);
+        }, 'json').fail(function(){
+            item.toggleClass('checked');
+            item.find('.teacher-msg')
+                .text(teacherErrorMsg)
+                .removeClass('text-success')
+                .addClass('text-danger');
+            setTimeout(function(){ item.find('.teacher-msg').text(''); }, 3000);
+        });
+    });
+});
+</script>
+JS;
+
+$search = trim($_GET['search'] ?? '');
+$limit = $_GET['limit'] ?? 10;
+$validLimits = ['10', '20', '30', '50', 'all'];
+if (!in_array((string) $limit, $validLimits, true)) {
+    $limit = 10;
+}
+$limitSql = '';
+$page = max(1, (int) ($_GET['page'] ?? 1));
+if ($limit !== 'all') {
+    $limit = (int) $limit;
+    $offset = ($page - 1) * $limit;
+    $limitSql = " LIMIT $limit OFFSET $offset";
+}
+
+$tblUser = Database::get_main_table(TABLE_MAIN_USER);
+$tblTeachers = Database::get_main_table(UserProfilePlugin::TABLE_TEACHERS);
+$urlId = api_get_current_access_url_id();
+
+$from = "$tblUser u";
+if (api_is_multiple_url_enabled()) {
+    $tblUrl = Database::get_main_table(TABLE_MAIN_ACCESS_URL_REL_USER);
+    $from .= " INNER JOIN $tblUrl url ON (u.id = url.user_id AND url.access_url_id = $urlId)";
+}
+
+$where = [];
+if ($search !== '') {
+    $escaped = Database::escape_string($search);
+    $where[] = "(u.firstname LIKE '%$escaped%' OR u.lastname LIKE '%$escaped%')";
+}
+$whereSql = $where ? ' WHERE '.implode(' AND ', $where) : '';
+
+$countSql = "SELECT COUNT(*) FROM $from$whereSql";
+$res = Database::query($countSql);
+$total = (int) Database::fetch_row($res)[0];
+
+$sql = "SELECT u.id, u.firstname, u.lastname, t.teacher_ids
+        FROM $from
+        LEFT JOIN $tblTeachers t ON u.id = t.user_id
+        $whereSql
+        ORDER BY u.lastname, u.firstname$limitSql";
+$res = Database::query($sql);
+$users = Database::store_result($res);
+
+$teacherOptions = $plugin->getTeacherOptions();
+
+Display::display_header(get_lang('TeacherManagement', 'user_profile'));
+
+// Navigation links between tracking, administrative tracking, and teacher assignment
+$current = basename($_SERVER['SCRIPT_NAME']);
+$links = [];
+if ($current === 'tracking.php') {
+    $links[] = 'Suivi pédagogique';
+} else {
+    $links[] = '<a href="tracking.php">Suivi pédagogique</a>';
+}
+if ($current === 'tracking_untracked.php') {
+    $links[] = 'Suivi administratif';
+} else {
+    $links[] = '<a href="tracking_untracked.php">Suivi administratif</a>';
+}
+if ($current === 'teachers.php') {
+    $links[] = get_lang('TeacherAssignment', 'user_profile');
+} else {
+    $links[] = '<a href="teachers.php">'.get_lang('TeacherAssignment', 'user_profile').'</a>';
+}
+echo '<div class="mb-3">'.implode(' | ', $links).'</div>';
+
+echo '<div class="user-profile-section">';
+
+echo '<form method="get" class="form-inline mb-3">';
+    echo '<input type="text" name="search" value="'.Security::remove_XSS($search).'" class="form-control mr-2" placeholder="'.get_lang('SearchUser', 'user_profile').'">';
+    echo '<select name="limit" class="form-control mr-2">';
+    foreach (['10','20','30','50','all'] as $opt) {
+        $selected = ($opt == ($_GET['limit'] ?? '10')) ? ' selected' : '';
+        $label = $opt === 'all' ? get_lang('All') : $opt;
+        echo '<option value="'.$opt.'"'.$selected.'>'.$label.'</option>';
+    }
+    echo '</select>';
+    echo '<button type="submit" class="btn btn-primary">'.get_lang('Search').'</button>';
+echo '</form>';
+
+echo '<table class="table table-striped">';
+    echo '<thead><tr><th>'.get_lang('FirstName').'</th><th>'.get_lang('LastName').'</th><th>'.get_lang('Teachers').'</th></tr></thead><tbody>';
+    foreach ($users as $user) {
+        $selected = $plugin->getUserTeachers((int) $user['id']);
+        echo '<tr>';
+        echo '<td>'.Security::remove_XSS($user['firstname']).'</td>';
+        echo '<td>'.Security::remove_XSS($user['lastname']).'</td>';
+        echo '<td>';
+        echo '<div class="teacher-list" data-user-id="'.(int) $user['id'].'">';
+        foreach ($teacherOptions as $tid => $name) {
+            $checked = in_array((int) $tid, $selected, true) ? ' checked' : '';
+            echo '<div class="teacher-item'.$checked.'" data-teacher-id="'.(int)$tid.'">';
+            echo '<span class="teacher-name">'.Security::remove_XSS($name).'</span>';
+            echo '<span class="teacher-check">&#10003;</span>';
+            echo '<span class="teacher-msg"></span>';
+            echo '</div>';
+        }
+        echo '</div>';
+        echo '</td>';
+        echo '</tr>';
+    }
+    if (empty($users)) {
+        echo '<tr><td colspan="3">'.get_lang('NoSearchResults').'</td></tr>';
+    }
+    echo '</tbody>';
+echo '</table>';
+
+if ($limit !== 'all' && $total > $limit) {
+    $totalPages = (int) ceil($total / $limit);
+    echo '<nav><ul class="pagination">';
+    for ($p = 1; $p <= $totalPages; $p++) {
+        $active = $p === $page ? ' active' : '';
+        $url = api_get_self().'?page='.$p.'&limit='.($_GET['limit'] ?? '10');
+        if ($search !== '') {
+            $url .= '&search='.urlencode($search);
+        }
+        echo '<li class="page-item'.$active.'"><a class="page-link" href="'.$url.'">'.$p.'</a></li>';
+    }
+    echo '</ul></nav>';
+}
+
+echo '</div>';
+
+Display::display_footer();
+

--- a/plugin/user_profile/tracking.php
+++ b/plugin/user_profile/tracking.php
@@ -10,6 +10,7 @@ require_once api_get_path(LIBRARY_PATH).'MyStudents.php';
 
 global $htmlHeadXtra;
 $token = Security::get_token();
+$noTeacherMsg = addslashes(get_lang('NoTeacher', 'user_profile'));
 $htmlHeadXtra[] = '<style>
     .user-profile.card {border:1px solid #eee;border-radius:4px;box-shadow:0 2px 4px rgba(0,0,0,0.05);margin-bottom:20px;}
     .user-profile .card-title {font-weight:bold;text-align:center;background:#f7f7f7;margin:0;padding:10px;}
@@ -48,15 +49,9 @@ $(function(){
         e.preventDefault();
         var $card = $(this).closest(".user-profile");
         var userId = $card.data("user-id");
-        var teacherId = $card.find(".teacher-select").val();
-        if(!teacherId){
-            alert("Veuillez sélectionner un formateur");
-            return;
-        }
         $.post("'.api_get_path(WEB_PLUGIN_PATH).'user_profile/ajax.php", {
             action: "warn",
             user_id: userId,
-            teacher_id: teacherId,
             sec_token: userProfileToken
         }, function(resp){
             if (resp && resp.token) {
@@ -64,6 +59,8 @@ $(function(){
             }
             if (resp && resp.status === \'ok\') {
                 alert("Message envoyé");
+            } else if (resp && resp.status === \'no_teacher\') {
+                alert("'.$noTeacherMsg.'");
             } else {
                 alert("Erreur lors de l\'envoi du message");
             }
@@ -133,9 +130,6 @@ if ($perPage !== 'all') {
     $userSql .= " ORDER BY lastname, firstname";
 }
 $users = Database::query($userSql);
-// Preload teachers for selection list
-$teachersRes = Database::query("SELECT id, firstname, lastname FROM $tblUser WHERE status = ".COURSEMANAGER." ORDER BY lastname, firstname");
-$teachers = Database::store_result($teachersRes);
 
 Display::display_header(get_lang('UserTracking', 'user_profile'));
 
@@ -152,6 +146,7 @@ if ($current === 'tracking_untracked.php') {
 } else {
     $links[] = '<a href="tracking_untracked.php">Suivi administratif</a>';
 }
+$links[] = '<a href="teachers.php">'.get_lang('TeacherAssignment', 'user_profile').'</a>';
 echo '<div class="mb-3">'.implode(' | ', $links).'</div>';
 
 echo '<div class="user-profile-section text-center">';
@@ -227,6 +222,12 @@ while ($user = Database::fetch_array($users)) {
     echo '<li class="list-group-item"><strong>'.get_lang('RegistrationDate').':</strong> '.Security::remove_XSS($registrationDate).'</li>';
     echo '<li class="list-group-item"><strong>'.get_lang('LastLogins').':</strong> '.$lastLogin.'</li>';
     echo '<li class="list-group-item"><strong>'.get_lang('Agenda').':</strong> '.$thisWeekBox.' | '.$nextWeekBox.' <button class="btn btn-warning ml-2 agenda-remind-btn">Relancer</button></li>';
+    $teacherNames = $plugin->getTeacherNamesForUser($userId);
+    if ($teacherNames === '') {
+        $teacherNames = '-';
+    }
+    echo '<li class="list-group-item"><strong>'.get_lang('Teachers').':</strong> '
+        .Security::remove_XSS($teacherNames).'</li>';
     echo '</ul>';
 
     // Time spent last week
@@ -323,20 +324,6 @@ while ($user = Database::fetch_array($users)) {
             echo '</tbody></table></div>';
             echo '</div>';
         }
-    }
-    // Selection list of teachers
-    if (!empty($teachers)) {
-        echo '<div class="mt-3">';
-        echo '<label>'.get_lang('Teacher').'</label>';
-        echo '<select class="form-control teacher-select">';
-        // Default empty option so no teacher is pre-selected
-        echo '<option value=""></option>';
-        foreach ($teachers as $teacher) {
-            $fullName = $teacher['firstname'].' '.$teacher['lastname'];
-            echo '<option value="'.((int) $teacher['id']).'">'.Security::remove_XSS($fullName).'</option>';
-        }
-        echo '</select>';
-        echo '</div>';
     }
     echo '<div class="text-center mt-3">';
     echo '<a class="btn btn-danger" title="Accéder au suivi" href="'.Security::remove_XSS($detailsUrl).'">Suivi</a>';

--- a/plugin/user_profile/tracking_untracked.php
+++ b/plugin/user_profile/tracking_untracked.php
@@ -120,6 +120,7 @@ if ($current === 'tracking_untracked.php') {
 } else {
     $links[] = '<a href="tracking_untracked.php">Suivi administratif</a>';
 }
+$links[] = '<a href="teachers.php">'.get_lang('TeacherAssignment', 'user_profile').'</a>';
 echo '<div class="mb-3">'.implode(' | ', $links).'</div>';
 
 echo '<div class="user-profile-section text-center">';
@@ -192,6 +193,12 @@ while ($user = Database::fetch_array($users)) {
 
     echo '<li class="list-group-item"><strong>'.get_lang('RegistrationDate').':</strong> '.Security::remove_XSS($registrationDate).'</li>';
     echo '<li class="list-group-item"><strong>'.get_lang('LastLogins').':</strong> '.$lastLogin.'</li>';
+    $teacherNames = $plugin->getTeacherNamesForUser($userId);
+    if ($teacherNames === '') {
+        $teacherNames = '-';
+    }
+    echo '<li class="list-group-item"><strong>'.get_lang('Teachers').':</strong> '
+        .Security::remove_XSS($teacherNames).'</li>';
     echo '</ul>';
 
     // Time spent last week

--- a/plugin/user_profile/view.php
+++ b/plugin/user_profile/view.php
@@ -81,6 +81,8 @@ $built = [
     get_lang('RegistrationDate') => $info['registration_date'],
     get_lang('LastLogins') => $info['last_login'],
 ];
+$teacherNames = UserProfilePlugin::create()->getTeacherNamesForUser($userId);
+$built[get_lang('Teachers')] = $teacherNames !== '' ? $teacherNames : '-';
 echo '<div class="card user-profile mb-3">';
 echo '<div class="card-title"><strong>'.get_lang('PlatformFields', 'user_profile').'</strong></div>';
 echo '<ul class="list-group list-group-flush">';

--- a/plugin/user_profile/xls.php
+++ b/plugin/user_profile/xls.php
@@ -31,6 +31,8 @@ foreach ($fields as $field) {
     $fieldsByCat[$field['category_id']][] = $field;
 }
 $categories = $plugin->getCategories();
+$teacherNames = $plugin->getTeacherNamesForUser($userId);
+$teacherDisplay = $teacherNames !== '' ? $teacherNames : '-';
 
 // Build a simple HTML table for Excel without style tags.
 $html  = '<table border="1">';
@@ -42,6 +44,7 @@ $html .= '<tr><td>'.get_lang('OfficialCode').'</td><td>'.Security::remove_XSS($i
 $html .= '<tr><td>'.get_lang('Phone').'</td><td>'.Security::remove_XSS($info['phone']).'</td></tr>';
 $html .= '<tr><td>'.get_lang('RegistrationDate').'</td><td>'.Security::remove_XSS($info['registration_date']).'</td></tr>';
 $html .= '<tr><td>'.get_lang('LastLogins').'</td><td>'.Security::remove_XSS($info['last_login']).'</td></tr>';
+$html .= '<tr><td>'.get_lang('Teachers').'</td><td>'.Security::remove_XSS($teacherDisplay).'</td></tr>';
 
 foreach ($categories as $cat) {
     $html .= '<tr><th colspan="2">'.Security::remove_XSS(UserProfilePlugin::getCategoryLabel($cat)).'</th></tr>';


### PR DESCRIPTION
## Summary
- create plugin_user_profile_teachers table on install and drop on uninstall
- allow assigning multiple teachers when adding or editing a user
- show assigned teacher names on user profile tracking pages, including administrative tracking, even when none are set
- display teacher names in user profile view
- warn button on tracking page now messages all assigned teachers and alerts when none exist
- warn messages only list overdue uncompleted date fields
- add teacher management page to search, paginate, and update teacher assignments for any user
- teacher assignments on management page show checkmarks and inline success or error messages as they auto-save via AJAX
- refactor teacher management page script to safely inject JSON-encoded messages
- include assigned teacher names in PDF and XLS exports and refresh the PDF template
- link administrative tracking to teacher assignment interface
- provide teacher-assignment navigation link on pedagogical tracking page and replicate tracking menu on teacher-management page

## Testing
- `php -l plugin/user_profile/pdf.php`
- `php -l plugin/user_profile/xls.php`
- `php -l plugin/user_profile/view.php`
- `php -l plugin/user_profile/UserProfilePlugin.php`
- `php -l plugin/user_profile/src/HookUserProfile.php`
- `php -l plugin/user_profile/lang/english.php`
- `php -l plugin/user_profile/lang/french.php`
- `php -l plugin/user_profile/teachers.php`
- `php -l main/admin/user_add.php`
- `php -l main/admin/user_edit.php`
- `php -l plugin/user_profile/tracking.php`
- `php -l plugin/user_profile/tracking_untracked.php`
- `php -l plugin/user_profile/view.php`
- `php -l plugin/user_profile/ajax.php`


------
https://chatgpt.com/codex/tasks/task_e_68aaf3b876d4832b83e1a07a731f0f59